### PR TITLE
Add issue/PR templates, Dependabot, and refresh CONTRIBUTING

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Report something that isn't working as expected
+title: ""
+labels: bug
+assignees: ""
+---
+
+## Description
+
+A clear and concise description of the bug.
+
+## Steps to reproduce
+
+1. Go to '...'
+2. Click on '...'
+3. See error
+
+## Expected behavior
+
+What you expected to happen.
+
+## Actual behavior
+
+What actually happened. Include a screenshot if it's a UI issue.
+
+## Environment
+
+- Browser / OS:
+- Service(s) affected (if a status looks wrong):
+
+## Additional context
+
+Anything else that might help.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,26 @@
+---
+name: Feature request
+about: Suggest a new service, source type, or improvement
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+## What would you like?
+
+A clear and concise description of the feature or service you'd like added.
+
+## For a new service
+
+- **Name:**
+- **Status source:** statuspage / slack / rss / http (see [CONTRIBUTING.md](../../CONTRIBUTING.md))
+- **Category it belongs in:**
+- **Why it belongs here:**
+
+## Motivation
+
+What problem does this solve, or who benefits?
+
+## Additional context
+
+Links, screenshots, or alternatives you considered.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## What does this PR do?
+
+A short description of the change.
+
+## Type of change
+
+- [ ] New service
+- [ ] Bug fix
+- [ ] UI change
+- [ ] Other (please describe)
+
+## Checklist
+
+- [ ] `npm run typecheck` passes
+- [ ] `npm test` passes
+- [ ] For a UI change, I've attached a screenshot
+- [ ] For a new service, I've followed [CONTRIBUTING.md](../CONTRIBUTING.md) (source type + category + logo)
+- [ ] PR is focused (one service or one fix)
+
+## Screenshots (if applicable)
+
+## Related issues
+
+Closes #

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  # npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      # Batch routine dev/runtime bumps into a single PR to cut noise.
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions used in workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ curl -s http://localhost:8787/api/status | jq
 ## Adding a service
 
 1. Append an entry to [`src/services.ts`](src/services.ts) with `id`, `name`, `category`, `weight`, and `source`.
-2. The logo is fetched automatically from DuckDuckGo's icon CDN using the service's domain — no extra step needed.
+2. If the service should show a logo, add its brand domain to the `LOGO_DOMAIN` map in [`public/app.js`](public/app.js) and drop a square PNG at `public/images/logo/services/<id>.png` (logos are self-hosted, not fetched from a CDN).
 3. Run the cron locally to verify the status resolves correctly.
 
 Source types:
@@ -52,10 +52,14 @@ Source types:
 
 Keep PRs focused. One service or one fix per PR is ideal.
 
-## Type checking
+## Type checking & tests
 
 ```sh
-npm run typecheck
+npm run typecheck   # tsc --noEmit
+npm test            # Vitest suite (runs inside workerd)
 ```
 
-No test suite is configured yet. Manual verification via `wrangler dev` is the current approach.
+Tests use Vitest with the Cloudflare Workers pool, so they execute against real
+local bindings. CI runs `npm run typecheck` and `npm test` on every PR (see
+[`.github/workflows/ci.yml`](.github/workflows/ci.yml)), and both must pass
+before a PR can merge into `main`. Use `npm run test:watch` while developing.


### PR DESCRIPTION
## What does this PR do?

Adds standard open-source repo scaffolding and refreshes contributor docs.

## Changes

- **Issue templates** — bug report and feature request (`.github/ISSUE_TEMPLATE/`)
- **PR template** — `.github/PULL_REQUEST_TEMPLATE.md` with a typecheck/test/screenshot checklist
- **Dependabot** — `.github/dependabot.yml`, weekly updates for npm + GitHub Actions, minor/patch grouped
- **CONTRIBUTING.md** — fixed two stale sections:
  - Logos are now self-hosted under `/images` (no longer fetched from the DuckDuckGo CDN)
  - Documented the Vitest suite + CI checks (the doc previously claimed no tests existed)

## Notes

Branch protection was also enabled on `main` (PR required, CI `check` must pass, force-push/deletion blocked). That's a repo setting, not part of this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)