### PR TITLE
Raise upstream fetch timeout from 8s to 15s

### DIFF
--- a/src/sources.ts
+++ b/src/sources.ts
@@ -10,7 +10,7 @@
 import { XMLParser } from "fast-xml-parser";
 import type { Service, ServiceDetails, ServiceSource, ServiceStatus, StatusLevel } from "./services";
 
-const UPSTREAM_TIMEOUT_MS = 8000;
+const UPSTREAM_TIMEOUT_MS = 15000;
 /** Edge-cache upstream responses for this long (seconds). */
 const UPSTREAM_CACHE_TTL = 30;
 /** RSS incidents older than this are treated as resolved/stale. */


### PR DESCRIPTION
## What

Bumps `UPSTREAM_TIMEOUT_MS` in `src/sources.ts` from `8000` → `15000`.

## Why

Slow first-party status pages — notably ones with long incident histories like AWS and Cursor — occasionally take longer than 8s to return their first byte. When they do, the abort in `fetchUpstream` fires and `resolveStatus` maps the `AbortError` to a `"Timed out"` / `unknown` result, even though the service is actually reachable.

Raising the wall-clock timeout to 15s gives those slow upstreams more room before we give up.

## Notes

- This is an **I/O wait**, not CPU work, so it does not affect Worker CPU time/billing — the Worker is parked awaiting the network, not executing.
- All three source types (`statuspage`, `rss`, `http`) route through `fetchUpstream`, so they all pick up the new value.
- Edge caching (`cacheTtl: 30`) is unchanged, so warm cache hits are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)