### PR TITLE
Temper Statuspage major outages by component breadth

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Every service is normalized to one of: `up` · `degraded` · `down` · `unknown`
 
 | Source type   | How status is derived |
 |---------------|-----------------------|
-| **Statuspage** | Reads `{base}/api/v2/summary.json` (Atlassian). `status.indicator` maps: `none`→`up`, `minor`/`maintenance`→`degraded`, `major`/`critical`→`down`. The summary also yields component rollups and active incidents for the detail view. |
+| **Statuspage** | Reads `{base}/api/v2/summary.json` (Atlassian). `status.indicator` maps: `none`→`up`, `minor`/`maintenance`→`degraded`. A `major`/`critical` indicator is **tempered by breadth** — since the indicator reflects peak component severity, not how much is affected — so it only reads `down` when the major outage is broad (≥50% of components, or too few components to judge); a localized one (e.g. a single region) → `degraded`. The summary also yields component rollups and active incidents for the detail view. |
 | **RSS / Atom** | Parses the latest feed entry (via `fast-xml-parser`). Entries older than 48h are treated as resolved (`up`). A fresh entry mentioning *resolved/restored/operational* → `up`; *outage/down/major/critical* → `down`; anything else fresh → `degraded`. Heuristic. |
 | **HTTP ping**  | A plain `GET`. `2xx`/`3xx` → `up`; other response → `degraded`; network error or timeout → `down`. |
 | *(any)*        | A failed fetch or timeout → `unknown` (treated as "no data" — never opens an incident or counts as downtime). |

--- a/scripts/probe-status.mjs
+++ b/scripts/probe-status.mjs
@@ -1,0 +1,123 @@
+/**
+ * Probe live upstream status for a category and dump the raw classification
+ * signal, so we can see how each provider reports state — and where the
+ * top-level indicator disagrees with the component-level reality.
+ *
+ *   node scripts/probe-status.mjs                       # Developer & Cloud
+ *   node scripts/probe-status.mjs "AI"                  # another category
+ *   node scripts/probe-status.mjs --all                 # every category
+ *
+ * Read-only: only GETs upstream status endpoints. Node 24 strips the TS types,
+ * so we import the real SERVICES list instead of duplicating it.
+ */
+
+import { SERVICES } from "../src/services.ts";
+
+const UA = "isUpMap-StatusMonitor/1.0 (+https://github.com)";
+const TIMEOUT_MS = 15000;
+
+async function get(url, init = {}) {
+	const ctrl = new AbortController();
+	const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+	try {
+		const res = await fetch(url, { ...init, signal: ctrl.signal, headers: { "user-agent": UA, ...(init.headers ?? {}) } });
+		return res;
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+/** Prod indicator → status mapping (mirrors statuspageStatus in src/sources.ts):
+ *  a major/critical indicator only reads as `down` when the major outage is
+ *  broad; a localized one (few components affected) is tempered to `degraded`. */
+const MIN_COMPONENTS = 4;
+const BROAD_MAJOR_FRACTION = 0.5;
+function indicatorToStatus(indicator, total, majorOutages) {
+	switch (indicator) {
+		case "none": return "up";
+		case "minor": case "maintenance": return "degraded";
+		case "major": case "critical":
+			if (total < MIN_COMPONENTS) return "down";
+			return majorOutages / total >= BROAD_MAJOR_FRACTION ? "down" : "degraded";
+		default: return "unknown";
+	}
+}
+
+async function probeStatuspage(svc, base) {
+	const res = await get(`${base.replace(/\/$/, "")}/api/v2/summary.json`);
+	if (!res.ok) return { verdict: "unknown", note: `HTTP ${res.status}` };
+	const data = await res.json();
+	const indicator = data.status?.indicator ?? "none";
+
+	// Per-component status histogram (skip group containers — they roll up children).
+	const comps = (data.components ?? []).filter((c) => c.group !== true);
+	const hist = {};
+	for (const c of comps) hist[c.status ?? "?"] = (hist[c.status ?? "?"] ?? 0) + 1;
+	const impacted = comps.filter((c) => c.status && c.status !== "operational");
+	const majorOutages = comps.filter((c) => c.status === "major_outage").length;
+
+	return {
+		verdict: indicatorToStatus(indicator, comps.length, majorOutages),
+		indicator,
+		desc: data.status?.description ?? "",
+		components: `${comps.length - impacted.length}/${comps.length} ok`,
+		hist,
+		impacted: impacted.map((c) => `${c.name}=${c.status}`),
+		incidents: (data.incidents ?? []).length,
+	};
+}
+
+async function probeRss(svc, url) {
+	const res = await get(url);
+	if (!res.ok) return { verdict: "unknown", note: `HTTP ${res.status}` };
+	const xml = await res.text();
+	// Cheap latest-entry peek (no XML lib needed for a probe).
+	const item = xml.match(/<(?:item|entry)\b[\s\S]*?<\/(?:item|entry)>/i)?.[0] ?? "";
+	const title = (item.match(/<title[^>]*>([\s\S]*?)<\/title>/i)?.[1] ?? "")
+		.replace(/<!\[CDATA\[|\]\]>/g, "").trim();
+	const date = item.match(/<(?:pubDate|updated|published)[^>]*>([\s\S]*?)<\/(?:pubDate|updated|published)>/i)?.[1]?.trim();
+	const body = (item.match(/<(?:description|summary|content)[^>]*>([\s\S]*?)<\/(?:description|summary|content)>/i)?.[1] ?? "")
+		.replace(/<!\[CDATA\[|\]\]>/g, "").replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+	return { verdict: "(rss)", title: title || "(no items)", date, bodyLead: body.slice(0, 160) };
+}
+
+async function probeHttp(svc, url) {
+	const start = Date.now();
+	const res = await get(url, { redirect: "follow" });
+	return { verdict: res.ok || (res.status >= 300 && res.status < 400) ? "up" : `HTTP ${res.status}`, ms: Date.now() - start, status: res.status };
+}
+
+async function probe(svc) {
+	try {
+		switch (svc.source.type) {
+			case "statuspage": return await probeStatuspage(svc, svc.source.base);
+			case "rss": return await probeRss(svc, svc.source.url);
+			case "http": return await probeHttp(svc, svc.source.url);
+		}
+	} catch (err) {
+		return { verdict: "ERROR", note: err?.name === "AbortError" ? "timeout" : String(err?.message ?? err) };
+	}
+}
+
+const arg = process.argv[2];
+const category = arg && arg !== "--all" ? arg : "Developer & Cloud";
+const list = arg === "--all" ? SERVICES : SERVICES.filter((s) => s.category === category);
+
+console.log(`\nProbing ${list.length} services${arg === "--all" ? " (all)" : ` in "${category}"`}\n${"=".repeat(72)}`);
+
+for (const svc of list) {
+	const r = await probe(svc);
+	const tag = `${svc.name} [${svc.source.type}]`.padEnd(28);
+	if (svc.source.type === "statuspage") {
+		console.log(`${tag} → ${String(r.verdict).toUpperCase().padEnd(9)} indicator=${r.indicator ?? "?"}  ${r.components ?? ""}`);
+		if (r.hist) console.log(`${" ".repeat(30)}hist=${JSON.stringify(r.hist)}  incidents=${r.incidents}`);
+		if (r.impacted?.length) console.log(`${" ".repeat(30)}impacted: ${r.impacted.join(", ")}`);
+		if (r.note) console.log(`${" ".repeat(30)}${r.note}`);
+	} else if (svc.source.type === "rss") {
+		console.log(`${tag} → ${r.title ?? r.note ?? ""}  ${r.date ? `(${r.date})` : ""}`);
+		if (r.bodyLead) console.log(`${" ".repeat(30)}body: ${r.bodyLead}`);
+	} else {
+		console.log(`${tag} → ${String(r.verdict).toUpperCase()}  ${r.ms != null ? `${r.ms}ms` : ""}  ${r.note ?? ""}`);
+	}
+}
+console.log("");

--- a/src/sources.ts
+++ b/src/sources.ts
@@ -68,6 +68,36 @@ interface StatuspageSummary {
 }
 
 /**
+ * A Statuspage indicator reflects *peak* component severity, not *breadth*: a
+ * single region in `major_outage` among hundreds of operational components still
+ * sets `indicator: "major"`. Mapping that straight to `down` paints a service
+ * fully red when ~98% of it is fine (observed on Elastic/Grafana during a
+ * single-region cloud outage). So for a major/critical indicator we consult the
+ * component rollup and only call it `down` when the major outage is *broad*;
+ * a localized one is tempered to `degraded`.
+ */
+const STATUSPAGE_MIN_COMPONENTS = 4;
+const STATUSPAGE_BROAD_MAJOR_FRACTION = 0.5;
+
+function statuspageStatus(indicator: string, total: number, majorOutages: number): StatusLevel {
+	switch (indicator) {
+		case "none":
+			return "up";
+		case "minor":
+		case "maintenance":
+			return "degraded";
+		case "major":
+		case "critical":
+			// Too few components to judge breadth (or none reported): trust the indicator.
+			if (total < STATUSPAGE_MIN_COMPONENTS) return "down";
+			// Broad major outage → down; a small, localized blast radius → degraded.
+			return majorOutages / total >= STATUSPAGE_BROAD_MAJOR_FRACTION ? "down" : "degraded";
+		default:
+			return "unknown";
+	}
+}
+
+/**
  * Atlassian Statuspage. We read `summary.json` (a superset of `status.json`)
  * so the hover card can show component rollups and active incidents.
  */
@@ -79,28 +109,14 @@ async function fetchStatuspage(service: Service, base: string): Promise<ServiceS
 	const indicator = data.status?.indicator ?? "none";
 	const description = data.status?.description ?? "";
 
-	let status: StatusLevel;
-	switch (indicator) {
-		case "none":
-			status = "up";
-			break;
-		case "minor":
-		case "maintenance":
-			status = "degraded";
-			break;
-		case "major":
-		case "critical":
-			status = "down";
-			break;
-		default:
-			status = "unknown";
-	}
-
 	// Component rollup (skip group containers, which roll up their children).
 	const components = (data.components ?? []).filter((c) => c.group !== true);
 	const total = components.length;
 	const impacted = components.filter((c) => c.status && c.status !== "operational").map((c) => c.name ?? "Unknown");
 	const operational = total - impacted.length;
+	const majorOutages = components.filter((c) => c.status === "major_outage").length;
+
+	const status = statuspageStatus(indicator, total, majorOutages);
 
 	const incident = data.incidents?.[0];
 	const details: ServiceDetails = {

--- a/test/sources.test.ts
+++ b/test/sources.test.ts
@@ -52,6 +52,28 @@ describe("statuspage", () => {
 		expect((await resolve()).status).toBe("down");
 	});
 
+	// Build N components, the first `major` of them in major_outage, the rest operational.
+	function components(total: number, major: number) {
+		return Array.from({ length: total }, (_, i) => ({ name: `c${i}`, status: i < major ? "major_outage" : "operational" }));
+	}
+
+	it("tempers a region-localized major outage to degraded", async () => {
+		// indicator=major but only 1 of 20 components down (a single region) → not a full outage.
+		fetchSpy.mockResolvedValue(reply(summaryBody("major", components(20, 1))));
+		expect((await resolve()).status).toBe("degraded");
+	});
+
+	it("keeps a broad major outage as down", async () => {
+		// A majority of components in major_outage → genuinely down.
+		fetchSpy.mockResolvedValue(reply(summaryBody("major", components(10, 6))));
+		expect((await resolve()).status).toBe("down");
+	});
+
+	it("trusts a major indicator when components are too few to judge breadth", async () => {
+		fetchSpy.mockResolvedValue(reply(summaryBody("major", components(2, 1))));
+		expect((await resolve()).status).toBe("down");
+	});
+
 	it("maps an unrecognized indicator to unknown", async () => {
 		fetchSpy.mockResolvedValue(reply(summaryBody("wat")));
 		expect((await resolve()).status).toBe("unknown");


### PR DESCRIPTION
## Problem

A service tile showed **DOWN** when the service was mostly fine — only one region or subsystem was actually impacted.

A Statuspage `indicator` reflects *peak* component severity, not *breadth*. A single region in `major_outage` among hundreds of operational components still sets `indicator: "major"`, which [`fetchStatuspage`](src/sources.ts) mapped straight to `down`. Observed live during a single-region cloud outage:

```
Elastic  → DOWN  indicator=major  531/544 ok   (7 major, all me-south-1/azure-westus2)
Grafana  → DOWN  indicator=major  453/462 ok   (7 major, all AWS UAE me-central-1)
```

Both read **DOWN** while ~98% operational — the same Middle East / UAE event AWS itself reports.

## Fix

`fetchStatuspage` now consults the component rollup it already computes. For a `major`/`critical` indicator:

- **< 4 components** (or none reported) → trust the indicator → `down` (can't judge breadth).
- **≥ 4 components** → `down` only when `major_outage / total ≥ 0.5` (broad); otherwise `degraded`.

`none`/`minor`/`maintenance` are unchanged. The active incident is still surfaced in the hover card — only the tile color softens from red to amber.

## Verification

- **54 tests pass**, typecheck clean. Three new cases pin the behavior (localized major → degraded, broad major → down, few components → down).
- Probe across **all 89 services**: Elastic and Grafana are the only services with a `major` indicator, and both now correctly read **DEGRADED**. The change is precisely scoped to the false-DOWN cases.

Adds `scripts/probe-status.mjs` to dump the raw per-source classification signal:
```
node scripts/probe-status.mjs            # Developer & Cloud
node scripts/probe-status.mjs "AI"       # one category
node scripts/probe-status.mjs --all      # everything
```

> Note: this tempers the **Statuspage** path only. The RSS path still classifies from a single feed entry's prose via the keyword heuristic — a separate, lower-accuracy path tracked for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)