### PR TITLE
Fix RSS classification for oldest-first incident feeds (status.io)

### DIFF
--- a/src/sources.ts
+++ b/src/sources.ts
@@ -170,6 +170,38 @@ const MAINT_RE = /\b(scheduled|maintenance)\b/i;
 const UP_RE = /\b(resolved|restored|recovered|completed|monitoring|operating normally|operational|back to normal)\b/i;
 
 /**
+ * Formal incident-update stage markers, as emitted by Statuspage / status.io /
+ * Instatus: each update reads `Timestamp <Stage> - text` (e.g. "Investigating -",
+ * "Monitoring -", "Resolved -"). The capture is the stage word; the trailing
+ * dash distinguishes a real stage label from the same word used in prose
+ * ("we are monitoring the situation"). The stage is usually wrapped in markup
+ * (`<b>Resolved</b> - …`), so we strip tags before matching.
+ */
+const STAGE_RE = /\b(investigating|identified|monitoring|resolved|completed|scheduled)\b\s*[-–—]/gi;
+
+/**
+ * Infer state from the formal stage markers in the body. Providers disagree on
+ * ordering — Slack lists updates newest-first, status.io (e.g. Roblox) lists them
+ * oldest-first — so position is unreliable. But an incident only advances
+ * (Investigating → Identified → Monitoring → Resolved), so the *furthest* stage
+ * present is the current one regardless of order: a body that reached "Resolved -"
+ * is up even if it opens with "Investigating -". Returns null when the body has
+ * no formal stage markers (prose bodies fall through to {@link leadingSignal}).
+ */
+function stageSignal(description: string, text: string): StatusLevel | null {
+	const plain = description.replace(/<[^>]+>/g, " ");
+	const stages = new Set<string>();
+	for (const m of plain.matchAll(STAGE_RE)) stages.add(m[1].toLowerCase());
+	if (stages.size === 0) return null;
+	// Recovering or done (incidents don't regress) → up.
+	if (stages.has("resolved") || stages.has("completed") || stages.has("monitoring")) return "up";
+	// Still active: severity from any down-keyword in the entry.
+	if (stages.has("investigating") || stages.has("identified")) return DOWN_RE.test(text) ? "down" : "degraded";
+	if (stages.has("scheduled")) return "degraded";
+	return null;
+}
+
+/**
  * Infer the current state from the entry **body**. These feeds concatenate
  * updates newest-first, so the *earliest* lifecycle keyword in the body is the
  * latest update and reflects the current state — e.g. a body that leads with
@@ -214,16 +246,22 @@ function classifyEntry(title: string, description: string): StatusLevel {
 		// "update" or an unrecognized state word: fall through.
 	}
 
-	// 2. Newest-first body scan (catches a body "resolved" under an "Incident:" title).
+	// 2. Formal stage markers ("Investigating -" … "Resolved -"): the furthest
+	//    stage reached wins, so a resolved status.io incident reads as up even when
+	//    its body lists updates oldest-first (e.g. Roblox).
+	const stage = stageSignal(description, text);
+	if (stage) return stage;
+
+	// 3. Prose body with no stage markers: newest-first leading keyword (Slack-style).
 	const lead = leadingSignal(description);
 	if (lead) return lead;
 
-	// 3. Title-only fallback (feeds whose body carries no lifecycle keyword).
+	// 4. Title-only fallback (feeds whose body carries no lifecycle keyword).
 	if (RESOLVED_RE.test(title)) return "up";
 	if (DOWN_RE.test(title)) return "down";
 	if (ACTIVE_RE.test(title)) return "degraded";
 
-	// 4. Fresh but genuinely ambiguous: don't assert an incident color.
+	// 5. Fresh but genuinely ambiguous: don't assert an incident color.
 	return "unknown";
 }
 

--- a/test/sources.test.ts
+++ b/test/sources.test.ts
@@ -140,6 +140,33 @@ describe("rss", () => {
 		expect(r.details?.incident).toBeUndefined();
 	});
 
+	it("reads a resolved status.io incident as up despite an oldest-first body (Roblox)", async () => {
+		// status.io lists updates oldest-first: Investigating → Monitoring → Resolved.
+		// The furthest stage (Resolved) is the current state, even though the body opens
+		// with "Investigating -".
+		// Mirrors the real feed: each stage is wrapped in markup (<b>Stage</b> - …).
+		const body =
+			"<small>June 2, 2026 16:40 PDT</small><br /><b>Investigating</b> - We are investigating an issue with the Roblox player failing to launch.<br /><br />" +
+			"<small>June 2, 2026 16:54 PDT</small><br /><b>Monitoring</b> - We have reverted the change and are seeing recovery.<br /><br />" +
+			"<small>June 2, 2026 17:29 PDT</small><br /><b>Resolved</b> - This incident is resolved.";
+		fetchSpy.mockResolvedValue(reply(rss("Issue opening Roblox on certain platforms", now(), body)));
+		const r = await resolve();
+		expect(r.status).toBe("up");
+		expect(r.details?.incident).toBeUndefined();
+	});
+
+	it("reads an incident that reached 'Monitoring -' as up regardless of a leading 'Investigating -'", async () => {
+		const body = "Investigating - elevated errors observed. Monitoring - mitigation applied, watching recovery.";
+		fetchSpy.mockResolvedValue(reply(rss("Some service event", now(), body)));
+		expect((await resolve()).status).toBe("up");
+	});
+
+	it("keeps a still-active 'Investigating -' incident as down when the body names an outage", async () => {
+		const body = "May 6 17:43 PDT Investigating - We are aware of a major outage affecting connectivity.";
+		fetchSpy.mockResolvedValue(reply(rss("Players may be unable to connect", now(), body)));
+		expect((await resolve()).status).toBe("down");
+	});
+
 	it("treats a body leading 'Investigating' as degraded (status.io-style)", async () => {
 		const body = "June 1, 2026 11:24 UTC Investigating - Customers may experience failures creating branches.";
 		fetchSpy.mockResolvedValue(reply(rss("Issue with project operations", now(), body)));


### PR DESCRIPTION
## Problem

A Roblox incident that the status page showed as **RESOLVED** surfaced on the map as **degraded**.

Roblox uses **status.io**, which lists incident updates **oldest-first** inside the feed body:

```
<b>Investigating</b> - We are investigating an issue with the Roblox player...
<b>Monitoring</b>     - We have reverted the change and are seeing recovery.
<b>Resolved</b>       - This incident is resolved.
```

[`leadingSignal`](src/sources.ts) classifies by the *first* lifecycle keyword, assuming **newest-first** ordering (which is how Slack's feed reads). So it saw "Investigating" at the top and returned `degraded`, even though the incident had progressed to Resolved at the bottom. A position-based heuristic can't serve both orderings.

## Fix

Add an ordering-independent `stageSignal` pass that runs before the positional one. It reads the **formal stage markers** (`Investigating -` … `Resolved -`) and applies **lifecycle precedence**: an incident only advances (Investigating → Identified → Monitoring → Resolved), so the *furthest* stage present is the current state — regardless of whether the feed is oldest- or newest-first.

Two real-world details handled:
- Stage labels are HTML-wrapped in live feeds (`<b>Resolved</b> -`), so tags are stripped before matching.
- The required trailing dash distinguishes a real stage label from the same word in prose ("we are monitoring the situation").

Prose bodies with no formal stage markers (Slack-style) still fall through to the existing newest-first `leadingSignal`, so nothing else changes.

## Verification

- Full suite **54 pass**, typecheck clean. Three new cases: oldest-first body that reached Resolved → `up`; a leading `Investigating -` that reached `Monitoring -` → `up`; a still-active `Investigating -` naming an outage → `down`.
- Confirmed against the **live** Roblox feed — now resolves to `up` with no active incident.

Independent of #12 (Statuspage breadth) — branched off `main`, touches only the RSS path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)