### PR TITLE
Add Ko-fi donation link to toolbar

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -186,6 +186,10 @@
 					<svg class="tbar-x-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.744l7.73-8.835L1.254 2.25H8.08l4.253 5.622 5.91-5.622Zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
 					<span class="tbar-social__handle">@JaironDevNull</span>
 				</a>
+					<a href="https://ko-fi.com/jaironlanda" class="tbar-btn tbar-btn--icon" target="_blank" rel="noopener" title="Support me on Ko-fi">
+						<i data-lucide="coffee"></i>
+						<span class="tbar-btn__label">Donate</span>
+					</a>
 			</div>
 		</header>
 		<div class="statusbar" role="status" aria-live="polite">


### PR DESCRIPTION
Adds a Ko-fi donation link to the toolbar, next to the GitHub and X links.

- Links to https://ko-fi.com/jaironlanda
- Uses the existing `tbar-btn--icon` styling with a Lucide `coffee` icon and a "Donate" label

🤖 Generated with [Claude Code](https://claude.com/claude-code)