### PR TITLE
perf: cut snapshot DB load via longer cache TTL + batched reads

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -133,25 +133,30 @@ function uptimeFraction(intervals: IncidentIntervalRow[], windowMs: number, now:
  * yet (so callers can fall back to a live fetch).
  */
 export async function readSnapshot(db: D1Database, now = Date.now()): Promise<{ updatedAt: number | null; services: ApiService[] } | null> {
-	const currentRows = await db.prepare("SELECT * FROM current").all<CurrentRow>();
-	if (currentRows.results.length === 0) return null;
-
+	// One round-trip for all three reads (current snapshot, recent incidents,
+	// last-run marker) instead of three sequential awaits. The empty-snapshot
+	// early-return below only fires at cold start (before the first cron), so
+	// running all three eagerly costs nothing in practice.
 	const since = now - WEEK_MS;
-	const incidentRows = await db
-		.prepare("SELECT service_id, status, started_at, ended_at FROM incidents WHERE ended_at IS NULL OR ended_at >= ?")
-		.bind(since)
-		.all<IncidentIntervalRow>();
+	const [currentRes, incidentRes, lastRunRes] = await db.batch([
+		db.prepare("SELECT * FROM current"),
+		db.prepare("SELECT service_id, status, started_at, ended_at FROM incidents WHERE ended_at IS NULL OR ended_at >= ?").bind(since),
+		db.prepare("SELECT value FROM meta WHERE key = 'last_run'"),
+	]);
+
+	const currentRows = currentRes.results as CurrentRow[];
+	if (currentRows.length === 0) return null;
 
 	const byService = new Map<string, IncidentIntervalRow[]>();
-	for (const iv of incidentRows.results) {
+	for (const iv of incidentRes.results as IncidentIntervalRow[]) {
 		const list = byService.get(iv.service_id) ?? [];
 		list.push(iv);
 		byService.set(iv.service_id, list);
 	}
 
-	const lastRun = await db.prepare("SELECT value FROM meta WHERE key = 'last_run'").first<{ value: string }>();
+	const lastRun = (lastRunRes.results as { value: string }[])[0];
 
-	const services: ApiService[] = currentRows.results.map((r) => {
+	const services: ApiService[] = currentRows.map((r) => {
 		const intervals = byService.get(r.service_id) ?? [];
 		return {
 			id: r.service_id,

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,9 @@ function json(body: unknown, init: ResponseInit = {}): Response {
 		...init,
 		headers: {
 			"content-type": "application/json; charset=utf-8",
-			"cache-control": "public, max-age=30",
+			// Cron refreshes the snapshot every 5 min, so a 2-min TTL stays well
+			// within the update cadence while roughly quartering cache misses.
+			"cache-control": "public, max-age=120",
 			// Defense-in-depth (the _headers file doesn't apply to Worker responses).
 			"x-content-type-options": "nosniff",
 			"referrer-policy": "no-referrer",


### PR DESCRIPTION
## Summary

D1 query analytics showed the `/api/status` + `/api/summary` read path (`readSnapshot`) accounting for **~91% of total DB runtime** — three queries (`SELECT * FROM current`, the incidents window scan, and `meta last_run`), each running on every cache miss. Latencies and indexing were already healthy (P99 1–4ms, rows-read/returned = 1); the lever was *volume of misses* and *serial round-trips*.

## Changes

- **Cache TTL 30s → 120s** (`src/index.ts`). The cron refreshes the snapshot every 5 min, so a 2-min TTL is always fresher than the data, while roughly **quartering** the cache-miss rate that drives those three queries.
- **Batched reads** (`src/db.ts`). `readSnapshot` did three sequential `await`s; they now go through a single `db.batch()` — one round-trip instead of three. The empty-snapshot early-return only fires at cold start, so running all three eagerly is free in practice.

## Impact

- Top-3 query `Count` (and total rows read) should drop ~3–4× as the longer TTL takes hold.
- Remaining cache misses see lower latency (3 round-trips → 1).
- Write path (cron upsert) is unchanged.

## Verification

- `npm run typecheck` — clean
- `npm test` — 61/61 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)