### PR TITLE
Disable services with unreliable status sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ read-only aggregator and is not affiliated with any of these services. The list
 lives in [src/services.ts](src/services.ts); for Statuspage entries the
 `/api/v2/summary.json` path is appended to the `base` shown below.
 
+Rows marked **⊘ disabled** have an upstream that no longer publishes a usable
+machine-readable feed, so their status can't be resolved. They are shown as
+permanently `unknown` (grey), hidden from the heatmap, and appear locked in the
+**Customize** panel with the reason on hover — see
+[Disabled services](#disabled-services) below.
+
 | Service | Category | Source | Endpoint / base |
 |---------|----------|--------|-----------------|
 | GitHub | Developer & Cloud | Statuspage | `https://www.githubstatus.com` |
@@ -106,10 +112,10 @@ lives in [src/services.ts](src/services.ts); for Statuspage entries the
 | Render | Developer & Cloud | Statuspage | `https://status.render.com` |
 | AWS | Developer & Cloud | RSS | `https://status.aws.amazon.com/rss/all.rss` |
 | Google Cloud | Developer & Cloud | RSS | `https://status.cloud.google.com/en/feed.atom` |
-| Microsoft Azure | Developer & Cloud | RSS | `https://azure.status.microsoft/en-us/status/feed/` |
+| Microsoft Azure | Developer & Cloud | RSS · **⊘ disabled** | `https://azure.status.microsoft/en-us/status/feed/` |
 | Supabase | Developer & Cloud | Statuspage | `https://status.supabase.com` |
 | Fly.io | Developer & Cloud | Statuspage | `https://status.flyio.net` |
-| Railway | Developer & Cloud | RSS | `https://railway.betteruptime.com/feed.rss` |
+| Railway | Developer & Cloud | RSS · **⊘ disabled** | `https://railway.betteruptime.com/feed.rss` |
 | Neon | Developer & Cloud | RSS | `https://neonstatus.com/pages/6878fc85709daa75be6c7e3c/rss` |
 | PlanetScale | Developer & Cloud | Statuspage | `https://www.planetscalestatus.com` |
 | Bunny.net | Developer & Cloud | Statuspage | `https://status.bunny.net` |
@@ -120,8 +126,8 @@ lives in [src/services.ts](src/services.ts); for Statuspage entries the
 | Elastic | Developer & Cloud | Statuspage | `https://status.elastic.co` |
 | New Relic | Developer & Cloud | Statuspage | `https://status.newrelic.com` |
 | Grafana | Developer & Cloud | Statuspage | `https://status.grafana.com` |
-| PagerDuty | Developer & Cloud | RSS | `https://status.pagerduty.com/history.rss` |
-| Algolia | Developer & Cloud | RSS | `https://status.algolia.com/history.rss` |
+| PagerDuty | Developer & Cloud | RSS · **⊘ disabled** | `https://status.pagerduty.com/history.rss` |
+| Algolia | Developer & Cloud | RSS · **⊘ disabled** | `https://status.algolia.com/history.rss` |
 | GitLab | Developer & Cloud | RSS | `https://status.gitlab.com/pages/5b36dc6502d06804c08349f7/rss` |
 | Docker | Developer & Cloud | RSS | `https://www.dockerstatus.com/pages/533c6539221ae15e3f000031/rss` |
 | Appwrite | Developer & Cloud | RSS | `https://status.appwrite.online/feed.rss` |
@@ -147,7 +153,7 @@ lives in [src/services.ts](src/services.ts); for Statuspage entries the
 | Shopify | Payments | Statuspage | `https://www.shopifystatus.com` |
 | Plaid | Payments | Statuspage | `https://status.plaid.com` |
 | Paddle | Payments | Statuspage | `https://paddlestatus.com` |
-| Lemon Squeezy | Payments | RSS | `https://ohdear.app/status-page/lemon-squeezy-status/subscribe-rss` |
+| Lemon Squeezy | Payments | RSS · **⊘ disabled** | `https://ohdear.app/status-page/lemon-squeezy-status/subscribe-rss` |
 | Square | Payments | Statuspage | `https://www.issquareup.com` |
 | Klarna | Payments | Statuspage | `https://status.klarna.com` |
 | Discord | Communication | Statuspage | `https://discordstatus.com` |
@@ -184,6 +190,26 @@ lives in [src/services.ts](src/services.ts); for Statuspage entries the
 | PlayStation Network | Gaming & Entertainment | HTTP ping | `https://status.playstation.com` |
 | Riot Games | Gaming & Entertainment | HTTP ping | `https://status.riotgames.com` |
 | Spotify | Gaming & Entertainment | HTTP ping | `https://open.spotify.com` |
+
+### Disabled services
+
+A service is **disabled** when its upstream stops publishing a status feed we can
+parse. Rather than show a stale or misleading state, a disabled service is set to
+`unknown` (grey), kept out of the heatmap, and listed — locked and labelled
+`disabled`, with the reason on hover — in the **Customize** panel. The resolver
+skips disabled services entirely (no fetch). To disable one, add a `disabled:
+"<reason>"` string to its entry in [src/services.ts](src/services.ts).
+
+Currently disabled (upstream no longer exposes a machine-readable feed, verified
+2026-06-05):
+
+| Service | Reason |
+|---------|--------|
+| Microsoft Azure | Global status feed publishes no machine-readable incident items (empty channel). |
+| Railway | Migrated to a JS-rendered status page (`status.railway.com`); the old Betterstack feed is empty. |
+| PagerDuty | `history.rss` now returns an HTML page instead of XML. |
+| Algolia | `history.rss` now returns an HTML page instead of XML. |
+| Lemon Squeezy | The Oh Dear feed URL now serves an HTML subscribe page instead of a feed. |
 
 To add a service, append an entry to [src/services.ts](src/services.ts) with its
 `category`, a `weight` (tile size), and a `source`. Brand logos are

--- a/public/app.js
+++ b/public/app.js
@@ -97,7 +97,9 @@ const prefs = loadPrefs();
 /** The services to actually render, after applying hide + problems-only prefs. */
 function visibleServices() {
 	if (!latest) return [];
-	let v = latest.filter((s) => !prefs.hidden.has(s.id));
+	// Disabled services (unreliable source) are never tiled — they only appear,
+	// locked, in the Customize panel.
+	let v = latest.filter((s) => !s.disabled && !prefs.hidden.has(s.id));
 	if (prefs.problemsOnly) v = v.filter((s) => s.status !== "up");
 	return v;
 }
@@ -107,7 +109,7 @@ function renderView() {
 	if (!latest) return;
 	const v = visibleServices();
 	if (v.length === 0) {
-		const anyVisible = latest.some((s) => !prefs.hidden.has(s.id));
+		const anyVisible = latest.some((s) => !s.disabled && !prefs.hidden.has(s.id));
 		const msg =
 			prefs.problemsOnly && anyVisible
 				? "✓ All selected services are operational"
@@ -597,7 +599,10 @@ function renderCustomize() {
 		byCategory.get(svc.category).push(svc);
 	}
 
-	const shown = latest.filter((s) => !prefs.hidden.has(s.id)).length;
+	// Disabled services can't be selected, so they're excluded from the
+	// shown/total tallies (which describe the selectable set).
+	const selectableTotal = latest.filter((s) => !s.disabled).length;
+	const shown = latest.filter((s) => !s.disabled && !prefs.hidden.has(s.id)).length;
 	const countEl = document.getElementById("customizeCount");
 	const searching = czQuery.length > 0;
 
@@ -611,8 +616,10 @@ function renderCustomize() {
 		if (matches.length === 0) continue;
 		matchCount += matches.length;
 
-		const allShown = items.every((s) => !prefs.hidden.has(s.id));
-		const shownInCat = items.filter((s) => !prefs.hidden.has(s.id)).length;
+		// Category toggle + counts only consider selectable (non-disabled) services.
+		const selectable = items.filter((s) => !s.disabled);
+		const allShown = selectable.length > 0 && selectable.every((s) => !prefs.hidden.has(s.id));
+		const shownInCat = selectable.filter((s) => !prefs.hidden.has(s.id)).length;
 		// Searching force-expands so matches are always visible.
 		const collapsed = !searching && czCollapsed.has(category);
 
@@ -621,14 +628,24 @@ function renderCustomize() {
 				<i data-lucide="chevron-down" class="cz-group__chevron" aria-hidden="true"></i>
 				<input class="cz-group__check" type="checkbox" data-category="${escapeHtml(category)}" ${allShown ? "checked" : ""} aria-label="Toggle all ${escapeHtml(category)}" />
 				<span class="cz-group__name">${escapeHtml(category)}</span>
-				<span class="cz-group__count">${shownInCat}/${items.length}</span>
+				<span class="cz-group__count">${shownInCat}/${selectable.length}</span>
 			</div>
 			<div class="cz-group__body">`;
 		for (const svc of matches) {
+			if (svc.disabled) {
+				// Locked row: can't be toggled; explains why on hover.
+				html += `<div class="cz-row is-disabled" title="${escapeHtml(svc.disabled)}">
+					<input type="checkbox" disabled />
+					<span class="dot is-unknown"></span>
+					<span class="cz-row__name">${escapeHtml(svc.name)}</span>
+					<span class="cz-badge">disabled</span>
+				</div>`;
+				continue;
+			}
 			html += `<label class="cz-row">
 				<input type="checkbox" data-id="${escapeHtml(svc.id)}" ${prefs.hidden.has(svc.id) ? "" : "checked"} />
 				<span class="dot is-${svc.status}"></span>
-				<span>${escapeHtml(svc.name)}</span>
+				<span class="cz-row__name">${escapeHtml(svc.name)}</span>
 			</label>`;
 		}
 		html += `</div></div>`;
@@ -640,7 +657,7 @@ function renderCustomize() {
 	} else {
 		countEl.textContent = searching
 			? `${matchCount} match${matchCount === 1 ? "" : "es"}`
-			: `${shown} of ${latest.length} shown`;
+			: `${shown} of ${selectableTotal} shown`;
 	}
 
 	customizeList.innerHTML = html;
@@ -666,7 +683,7 @@ customizeList.addEventListener("change", (e) => {
 		if (cb.checked) prefs.hidden.delete(cb.dataset.id);
 		else prefs.hidden.add(cb.dataset.id);
 	} else if (cb.dataset.category) {
-		for (const svc of latest.filter((s) => s.category === cb.dataset.category)) {
+		for (const svc of latest.filter((s) => s.category === cb.dataset.category && !s.disabled)) {
 			if (cb.checked) prefs.hidden.delete(svc.id);
 			else prefs.hidden.add(svc.id);
 		}

--- a/public/styles.css
+++ b/public/styles.css
@@ -736,6 +736,35 @@ body {
 	background: var(--unknown);
 }
 
+.cz-row__name {
+	flex: 1;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+/* Disabled services: shown but not selectable (unreliable upstream source). */
+.cz-row.is-disabled {
+	cursor: help;
+	opacity: 0.55;
+}
+.cz-row.is-disabled input {
+	cursor: not-allowed;
+}
+
+.cz-badge {
+	flex: none;
+	font-size: 0.62rem;
+	font-weight: 600;
+	letter-spacing: 0.03em;
+	text-transform: uppercase;
+	color: var(--unknown);
+	border: 1px solid var(--unknown);
+	border-radius: 0.6rem;
+	padding: 0.05rem 0.4rem;
+}
+
 /* --- Incidents panel --- */
 .panel {
 	position: fixed;

--- a/src/db.ts
+++ b/src/db.ts
@@ -57,6 +57,8 @@ export interface ApiService {
 	description: string;
 	details?: unknown;
 	uptime: { day: number; week: number };
+	/** Reason the service is disabled (unreliable source), if applicable. */
+	disabled?: string;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,24 @@ interface Snapshot {
 	services: ApiService[];
 }
 
+/** Reasons keyed by service id for services disabled due to an unreliable source. */
+const DISABLED_REASONS = new Map(SERVICES.filter((s) => s.disabled).map((s) => [s.id, s.disabled as string]));
+
+/**
+ * `disabled` is static config (not persisted), so stamp it onto the snapshot on
+ * read and force those services to `unknown` regardless of any stale stored row.
+ */
+function decorateDisabled(services: ApiService[]): void {
+	for (const s of services) {
+		const reason = DISABLED_REASONS.get(s.id);
+		if (reason) {
+			s.disabled = reason;
+			s.status = "unknown";
+			s.description = reason;
+		}
+	}
+}
+
 /**
  * Load the current snapshot the way the public API exposes it: a fast D1 read,
  * with any service added to SERVICES but not yet persisted surfaced as
@@ -90,9 +108,12 @@ async function loadSnapshot(env: Env): Promise<{ snapshot: Snapshot; fromDb: boo
 				fromDb.services.push({ id: svc.id, name: svc.name, category: svc.category, weight: svc.weight, status: "unknown", description: "Pending first check", uptime: { day: 1, week: 1 } });
 			}
 		}
+		decorateDisabled(fromDb.services);
 		return { snapshot: fromDb, fromDb: true };
 	}
-	return { snapshot: liveSnapshot(await resolveAll()), fromDb: false };
+	const live = liveSnapshot(await resolveAll());
+	decorateDisabled(live.services);
+	return { snapshot: live, fromDb: false };
 }
 
 export interface StatusSummary {

--- a/src/services.ts
+++ b/src/services.ts
@@ -28,6 +28,13 @@ export interface Service {
 	category: string;
 	weight: number;
 	source: ServiceSource;
+	/**
+	 * If set, the service is shown as permanently `unknown` (grey) and cannot be
+	 * resolved/selected — its upstream no longer publishes a usable status feed.
+	 * The string is the human-readable reason, surfaced in the Customize panel on
+	 * hover. Disabled services are skipped by the resolver (no fetch).
+	 */
+	disabled?: string;
 }
 
 /** Extra context shown in the hover card. All fields optional/best-effort. */
@@ -55,6 +62,8 @@ export interface ServiceStatus {
 	description: string;
 	/** Optional richer data surfaced on hover. */
 	details?: ServiceDetails;
+	/** Reason the service is disabled (unreliable source), if applicable. */
+	disabled?: string;
 }
 
 export const SERVICES: Service[] = [
@@ -74,12 +83,14 @@ export const SERVICES: Service[] = [
 	{ id: "aws", name: "AWS", category: "Developer & Cloud", weight: 10, source: { type: "rss", url: "https://status.aws.amazon.com/rss/all.rss" } },
 	// Google Cloud publishes an Atom incident feed (not an Atlassian Statuspage).
 	{ id: "gcp", name: "Google Cloud", category: "Developer & Cloud", weight: 10, source: { type: "rss", url: "https://status.cloud.google.com/en/feed.atom", statusUrl: "https://status.cloud.google.com/" } },
-	// Azure publishes an RSS incident feed (not an Atlassian Statuspage).
-	{ id: "azure", name: "Microsoft Azure", category: "Developer & Cloud", weight: 10, source: { type: "rss", url: "https://azure.status.microsoft/en-us/status/feed/", statusUrl: "https://azure.status.microsoft/en-us/status" } },
+	// Azure's global status feed no longer publishes machine-readable incident
+	// items (empty channel), so its status can't be resolved reliably.
+	{ id: "azure", name: "Microsoft Azure", category: "Developer & Cloud", weight: 10, source: { type: "rss", url: "https://azure.status.microsoft/en-us/status/feed/", statusUrl: "https://azure.status.microsoft/en-us/status" }, disabled: "Azure's status feed no longer publishes machine-readable incidents, so its status can't be resolved." },
 	{ id: "supabase", name: "Supabase", category: "Developer & Cloud", weight: 6, source: { type: "statuspage", base: "https://status.supabase.com" } },
 	{ id: "flyio", name: "Fly.io", category: "Developer & Cloud", weight: 5, source: { type: "statuspage", base: "https://status.flyio.net" } },
-	// Railway uses Betterstack (not Atlassian Statuspage) — RSS is the reliable path.
-	{ id: "railway", name: "Railway", category: "Developer & Cloud", weight: 4, source: { type: "rss", url: "https://railway.betteruptime.com/feed.rss" } },
+	// Railway moved to a JS-rendered status page (status.railway.com) with no
+	// machine-readable feed; the old Betterstack feed is empty/abandoned.
+	{ id: "railway", name: "Railway", category: "Developer & Cloud", weight: 4, source: { type: "rss", url: "https://railway.betteruptime.com/feed.rss", statusUrl: "https://status.railway.com" }, disabled: "Railway's status page no longer exposes a machine-readable feed, so its status can't be resolved." },
 	// Neon uses status.io — RSS is the reliable path.
 	{ id: "neon", name: "Neon", category: "Developer & Cloud", weight: 4, source: { type: "rss", url: "https://neonstatus.com/pages/6878fc85709daa75be6c7e3c/rss" } },
 	{ id: "planetscale", name: "PlanetScale", category: "Developer & Cloud", weight: 4, source: { type: "statuspage", base: "https://www.planetscalestatus.com" } },
@@ -93,9 +104,10 @@ export const SERVICES: Service[] = [
 	{ id: "elastic", name: "Elastic", category: "Developer & Cloud", weight: 4, source: { type: "statuspage", base: "https://status.elastic.co" } },
 	{ id: "newrelic", name: "New Relic", category: "Developer & Cloud", weight: 4, source: { type: "statuspage", base: "https://status.newrelic.com" } },
 	{ id: "grafana", name: "Grafana", category: "Developer & Cloud", weight: 4, source: { type: "statuspage", base: "https://status.grafana.com" } },
-	// PagerDuty & Algolia gate their Statuspage JSON API (403/empty) but leave the RSS feed open.
-	{ id: "pagerduty", name: "PagerDuty", category: "Developer & Cloud", weight: 4, source: { type: "rss", url: "https://status.pagerduty.com/history.rss" } },
-	{ id: "algolia", name: "Algolia", category: "Developer & Cloud", weight: 4, source: { type: "rss", url: "https://status.algolia.com/history.rss" } },
+	// PagerDuty & Algolia migrated to JS-rendered status pages — their RSS feeds
+	// now return an HTML document instead of XML, so neither can be parsed.
+	{ id: "pagerduty", name: "PagerDuty", category: "Developer & Cloud", weight: 4, source: { type: "rss", url: "https://status.pagerduty.com/history.rss" }, disabled: "PagerDuty's RSS feed now returns an HTML page instead of a feed, so its status can't be resolved." },
+	{ id: "algolia", name: "Algolia", category: "Developer & Cloud", weight: 4, source: { type: "rss", url: "https://status.algolia.com/history.rss" }, disabled: "Algolia's RSS feed now returns an HTML page instead of a feed, so its status can't be resolved." },
 	// GitLab uses status.io (not Atlassian Statuspage) — RSS is the reliable path.
 	{ id: "gitlab", name: "GitLab", category: "Developer & Cloud", weight: 6, source: { type: "rss", url: "https://status.gitlab.com/pages/5b36dc6502d06804c08349f7/rss" } },
 	// Docker uses status.io (not Atlassian Statuspage) — RSS is the reliable path.
@@ -135,9 +147,9 @@ export const SERVICES: Service[] = [
 	{ id: "shopify", name: "Shopify", category: "Payments", weight: 6, source: { type: "statuspage", base: "https://www.shopifystatus.com" } },
 	{ id: "plaid", name: "Plaid", category: "Payments", weight: 4, source: { type: "statuspage", base: "https://status.plaid.com" } },
 	{ id: "paddle", name: "Paddle", category: "Payments", weight: 3, source: { type: "statuspage", base: "https://paddlestatus.com" } },
-	// Lemon Squeezy uses Oh Dear for status — RSS is the reliable path.
-	// statusUrl needed: the feed lives at a sub-path of ohdear.app, so origin alone would link to the wrong page.
-	{ id: "lemonsqueezy", name: "Lemon Squeezy", category: "Payments", weight: 3, source: { type: "rss", url: "https://ohdear.app/status-page/lemon-squeezy-status/subscribe-rss", statusUrl: "https://ohdear.app/status-page/lemon-squeezy-status" } },
+	// Lemon Squeezy's Oh Dear feed URL now serves an HTML subscribe page rather
+	// than a feed, so its status can't be resolved.
+	{ id: "lemonsqueezy", name: "Lemon Squeezy", category: "Payments", weight: 3, source: { type: "rss", url: "https://ohdear.app/status-page/lemon-squeezy-status/subscribe-rss", statusUrl: "https://status.lemonsqueezy.com" }, disabled: "Lemon Squeezy's status feed now returns an HTML page instead of a feed, so its status can't be resolved." },
 	{ id: "square", name: "Square", category: "Payments", weight: 5, source: { type: "statuspage", base: "https://www.issquareup.com" } },
 	{ id: "klarna", name: "Klarna", category: "Payments", weight: 4, source: { type: "statuspage", base: "https://status.klarna.com" } },
 

--- a/src/sources.ts
+++ b/src/sources.ts
@@ -345,6 +345,11 @@ async function fetchHttp(service: Service, url: string): Promise<ServiceStatus> 
 
 /** Resolve a single service's status, mapping any failure to `unknown`. */
 export async function resolveStatus(service: Service): Promise<ServiceStatus> {
+	// Disabled services have no usable upstream feed — skip the fetch and surface
+	// them as permanently `unknown` with the reason as the description.
+	if (service.disabled) {
+		return { ...result(service, "unknown", service.disabled), disabled: service.disabled };
+	}
 	try {
 		switch (service.source.type) {
 			case "statuspage":

--- a/test/sources.test.ts
+++ b/test/sources.test.ts
@@ -304,3 +304,15 @@ describe("error handling", () => {
 		expect(r.description).toBe("Timed out");
 	});
 });
+
+describe("disabled services", () => {
+	it("short-circuits to unknown without fetching, surfacing the reason", async () => {
+		const reason = "Upstream no longer publishes a usable feed.";
+		const service: Service = { ...svc({ type: "rss", url: "https://example.com/feed.rss" }), disabled: reason };
+		const r = await resolveStatus(service);
+		expect(r.status).toBe("unknown");
+		expect(r.description).toBe(reason);
+		expect(r.disabled).toBe(reason);
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary

Five services no longer publish a machine-readable status feed, so the heatmap was showing stale or wrong state. Rather than mislead, they're now marked **disabled**.

Live probes (2026-06-05) found:

| Service | Problem |
|---------|---------|
| Microsoft Azure | Global status feed publishes no machine-readable incident items (empty channel) → silently always "up" |
| Railway | Migrated to a JS status page (`status.railway.com`); old Betterstack feed is empty → silently always "up" |
| PagerDuty | `history.rss` now returns an HTML page instead of XML → parse fails |
| Algolia | `history.rss` now returns an HTML page instead of XML → parse fails |
| Lemon Squeezy | Oh Dear feed URL now serves an HTML subscribe page instead of a feed → parse fails |

## Behavior

A disabled service (new `disabled: "<reason>"` on its entry):
- shows as **`unknown` / grey** and is **never tiled** in the heatmap
- appears as a **locked row** in the **Customize** panel — checkbox disabled, `disabled` badge, reason on hover
- is **skipped by the resolver** (no upstream fetch), so it's also 5 fewer calls per cron run

Source of truth stays in `src/services.ts`; the flag is stamped onto the snapshot on read (not persisted in D1).

## Changes
- `src/services.ts` — `disabled?` on `Service`/`ServiceStatus`; mark the 5
- `src/sources.ts` — `resolveStatus` short-circuits disabled → `unknown` without fetching
- `src/index.ts` + `src/db.ts` — decorate the snapshot with `disabled`, forcing `unknown`
- `public/app.js` + `public/styles.css` — hide from grid; locked Customize row + badge
- `README.md` — mark the rows ⊘ disabled and add a **Disabled services** section
- `test/sources.test.ts` — new case: disabled returns `unknown`/reason and does not fetch

## Testing
- `npm run typecheck` — clean
- `npm test` — 62/62 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)