### PR TITLE
docs: align README endpoints with the URLs actually probed

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,8 +187,8 @@ permanently `unknown` (grey), hidden from the heatmap, and appear locked in the
 | Netflix | Gaming & Entertainment | HTTP ping | `https://www.netflix.com` |
 | Roblox | Gaming & Entertainment | RSS | `https://status.roblox.com/pages/59db90dbcdeb2f04dadcf16d/rss` |
 | Steam | Gaming & Entertainment | HTTP ping | `https://store.steampowered.com` |
-| PlayStation Network | Gaming & Entertainment | HTTP ping | `https://status.playstation.com` |
-| Riot Games | Gaming & Entertainment | HTTP ping | `https://status.riotgames.com` |
+| PlayStation Network | Gaming & Entertainment | HTTP ping | `https://www.playstation.com` |
+| Riot Games | Gaming & Entertainment | HTTP ping | `https://www.riotgames.com` |
 | Spotify | Gaming & Entertainment | HTTP ping | `https://open.spotify.com` |
 
 ### Disabled services


### PR DESCRIPTION
## Summary

While comparing the README **Data sources** table against `src/services.ts`, two rows didn't tally. Both are `http`-ping services whose Endpoint column listed the **status-page URL** (the `statusUrl` link target) instead of the URL the heatmap actually pings:

| Service | Was (README) | Now — actual ping target ([services.ts](src/services.ts)) |
|---------|--------------|------------------------------------------------|
| PlayStation Network | `https://status.playstation.com` | `https://www.playstation.com` |
| Riot Games | `https://status.riotgames.com` | `https://www.riotgames.com` |

Every other row shows the probed URL; this makes these two consistent. All 87 rows now match `src/services.ts` (verified programmatically — 0 URL mismatches, names tally exactly).

> Note: supersedes the direct-to-main commit `6d54cf5`, which was reverted (`8f9c8be`) so the change lands through a PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)