### PR TITLE
Disable Auth0 (stale/invalid status feed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ permanently `unknown` (grey), hidden from the heatmap, and appear locked in the
 | Neon | Developer & Cloud | RSS | `https://neonstatus.com/pages/6878fc85709daa75be6c7e3c/rss` |
 | PlanetScale | Developer & Cloud | Statuspage | `https://www.planetscalestatus.com` |
 | Bunny.net | Developer & Cloud | Statuspage | `https://status.bunny.net` |
-| Auth0 | Developer & Cloud | Statuspage | `https://auth0.statuspage.io` |
+| Auth0 | Developer & Cloud | Statuspage · **⊘ disabled** | `https://auth0.statuspage.io` |
 | Clerk | Developer & Cloud | Statuspage | `https://status.clerk.com` |
 | HashiCorp | Developer & Cloud | Statuspage | `https://status.hashicorp.com` |
 | Snowflake | Developer & Cloud | Statuspage | `https://status.snowflake.com` |
@@ -193,8 +193,9 @@ permanently `unknown` (grey), hidden from the heatmap, and appear locked in the
 
 ### Disabled services
 
-A service is **disabled** when its upstream stops publishing a status feed we can
-parse. Rather than show a stale or misleading state, a disabled service is set to
+A service is **disabled** when its upstream no longer provides a status feed we can
+trust — it stopped publishing a machine-readable feed, or the feed reports stale /
+incorrect state. Rather than show a stale or misleading status, a disabled service is set to
 `unknown` (grey), kept out of the heatmap, and listed — locked and labelled
 `disabled`, with the reason on hover — in the **Customize** panel. The resolver
 skips disabled services entirely (no fetch). To disable one, add a `disabled:
@@ -206,6 +207,7 @@ Currently disabled (upstream no longer exposes a machine-readable feed, verified
 | Service | Reason |
 |---------|--------|
 | Microsoft Azure | Global status feed publishes no machine-readable incident items (empty channel). |
+| Auth0 | Statuspage JSON (`auth0.statuspage.io`) is stale — reports a phantom "minor outage" with no active incident while the live page shows all operational. |
 | Railway | Migrated to a JS-rendered status page (`status.railway.com`); the old Betterstack feed is empty. |
 | PagerDuty | `history.rss` now returns an HTML page instead of XML. |
 | Algolia | `history.rss` now returns an HTML page instead of XML. |

--- a/src/services.ts
+++ b/src/services.ts
@@ -96,8 +96,10 @@ export const SERVICES: Service[] = [
 	{ id: "planetscale", name: "PlanetScale", category: "Developer & Cloud", weight: 4, source: { type: "statuspage", base: "https://www.planetscalestatus.com" } },
 	// Bunny.net CDN
 	{ id: "bunny", name: "Bunny.net", category: "Developer & Cloud", weight: 3, source: { type: "statuspage", base: "https://status.bunny.net" } },
-	// Auth0's Statuspage lives at auth0.statuspage.io (status.auth0.com lacks the JSON API).
-	{ id: "auth0", name: "Auth0", category: "Developer & Cloud", weight: 5, source: { type: "statuspage", base: "https://auth0.statuspage.io" } },
+	// Auth0's Statuspage JSON (auth0.statuspage.io — status.auth0.com lacks the JSON API)
+	// is stale: it reports a phantom "Minor Service Outage" with no active incident while
+	// the live status page shows all systems operational, so it can't be trusted.
+	{ id: "auth0", name: "Auth0", category: "Developer & Cloud", weight: 5, source: { type: "statuspage", base: "https://auth0.statuspage.io" }, disabled: "Auth0's status feed is stale — it reports a phantom 'minor outage' with no active incident while the live status page shows all systems operational." },
 	{ id: "clerk", name: "Clerk", category: "Developer & Cloud", weight: 4, source: { type: "statuspage", base: "https://status.clerk.com" } },
 	{ id: "hashicorp", name: "HashiCorp", category: "Developer & Cloud", weight: 4, source: { type: "statuspage", base: "https://status.hashicorp.com" } },
 	{ id: "snowflake", name: "Snowflake", category: "Developer & Cloud", weight: 6, source: { type: "statuspage", base: "https://status.snowflake.com" } },


### PR DESCRIPTION
## Summary

Auth0's status source reports a **phantom outage** and can't be trusted, so disable it (same mechanism as the other disabled services).

Verified live (2026-06-05):

| Source | Result |
|--------|--------|
| `auth0.statuspage.io/api/v2/summary.json` (what the code reads — the only host with the JSON API) | `indicator: minor` / "Minor Service Outage", but **0 open incidents** and `page.updated_at` = 2026-06-01 (4 days stale) |
| `status.auth0.com` (live human page) | **"All Systems Operational"** |

So the feed is stuck flagging a minor outage that no longer exists. Rather than show a misleading red/amber tile, Auth0 is now disabled: rendered `unknown`/grey, hidden from the heatmap, and listed locked in **Customize** with the reason on hover. The resolver skips fetching it.

## Changes
- `src/services.ts` — add `disabled` reason to the Auth0 entry (+ explanatory comment)
- `README.md` — mark the Auth0 row ⊘ disabled, add it to the disabled-services table, and broaden the section intro to cover *stale/incorrect* feeds (not just missing ones)

## Testing
- `npm run typecheck` — clean
- `npm test` — 62/62 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)