### PR TITLE
fix: bypass browser HTTP cache on live API polls

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -123,7 +123,10 @@ function renderView() {
 
 async function poll() {
 	try {
-		const res = await fetch("/api/status", { headers: { accept: "application/json" } });
+		// `no-store` bypasses the browser HTTP cache so the 45s poll always gets a
+		// fresh snapshot. Cloudflare's edge cache still serves (and shields D1) —
+		// `no-store` is a browser-only directive and doesn't bust the edge cache.
+		const res = await fetch("/api/status", { cache: "no-store", headers: { accept: "application/json" } });
 		if (!res.ok) throw new Error(`HTTP ${res.status}`);
 		const data = await res.json();
 		latest = data.services;
@@ -516,7 +519,7 @@ function formatDuration(ms) {
 async function loadIncidents() {
 	incidentsList.innerHTML = `<p class="panel__empty">Loading…</p>`;
 	try {
-		const res = await fetch("/api/incidents?limit=40", { headers: { accept: "application/json" } });
+		const res = await fetch("/api/incidents?limit=40", { cache: "no-store", headers: { accept: "application/json" } });
 		if (!res.ok) throw new Error(`HTTP ${res.status}`);
 		const { incidents } = await res.json();
 		renderIncidents(incidents);
@@ -1171,7 +1174,7 @@ async function openDetail(svc) {
 	// Incident history for this service (client-side filter of the recent log).
 	detailBody.querySelector(".detail__incidents").innerHTML = `<p class="panel__empty">Loading history…</p>`;
 	try {
-		const res = await fetch("/api/incidents?limit=100", { headers: { accept: "application/json" } });
+		const res = await fetch("/api/incidents?limit=100", { cache: "no-store", headers: { accept: "application/json" } });
 		const { incidents } = await res.json();
 		const mine = incidents.filter((i) => i.serviceId === svc.id);
 		renderDetailIncidents(mine);


### PR DESCRIPTION
## Problem

Users had to **hard refresh** to see the heatmap update. The page shell (HTML/JS/CSS) is fine — it's served with `max-age=0, must-revalidate` and revalidates on every reload. The stale part was the **live status data**.

The deployed `/api/status` is served to browsers with `cache-control: public, max-age=14400` (4h), even though the Worker sets `max-age=120` ([src/index.ts:26](../blob/main/src/index.ts#L26)). `14400` appears nowhere in the repo — it's injected by a Cloudflare **zone** setting (Browser Cache TTL) that overrides `max-age` on CDN-cached responses.

The client polls every 45s with a plain `fetch()` and no cache-busting, so the poll loop **and** soft reloads both read the browser-cached JSON. Only a hard refresh bypasses it.

## Fix

Add `cache: "no-store"` to the three data-polling fetches in [public/app.js](../blob/main/public/app.js) so each poll reaches the network:

- `/api/status` (45s poll)
- `/api/incidents?limit=40`
- `/api/incidents?limit=100`

Safe for backend load: `no-store` is a **browser-only** directive — Cloudflare's edge cache still serves these (`cf-cache-status: HIT`) and shields D1.

## Note (out of scope, dashboard)

The root-cause override lives in Cloudflare: **Caching → Configuration → Browser Cache TTL**. Setting it to "Respect Existing Headers" would honor the Worker's `max-age` instead of forcing 4h. Optional now that the client bypasses the cache.

## Verification

- `npm run dev`, DevTools → Network: `/api/status` fires every ~45s with `200`, not `(disk cache)`.
- Soft reload (or one poll cycle) now reflects status changes without a hard refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)