### PR TITLE
feat: add shields.io badge format to /api/summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # isUpMap — Service Status Heatmap
 
+[![isUpMap status](https://img.shields.io/endpoint?url=https%3A%2F%2Fisupmap.com%2Fapi%2Fsummary%3Fformat%3Dshields)](https://isupmap.com)
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/Jaironlanda/isupmap)
 
 **Live: [isUpMap](https://isupmap.com)** (Official)
@@ -58,6 +59,8 @@ Browser (public/) ─poll /api/status every 45s─▶ Worker reads D1 (Cache-API
 - `GET /api/summary` returns a single **overall-status rollup** (worst status
   wins) plus a headline (`"All systems operational"` / `"2 down, 1 degraded"`)
   and per-status counts — handy for compact embeds, badges, or a status banner.
+  Add `?format=shields` for a [shields.io endpoint badge](https://shields.io/badges/endpoint-badge)
+  payload (status-colored), which powers the live badge at the top of this README.
   Same D1-read/live-fallback and Cache-API fronting as `/api/status`.
 - All API routes are **rate-limited** per IP (60 req / 60s) via a Workers
   rate-limit binding.

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,6 +129,26 @@ export interface StatusSummary {
 	updatedAt: number | null;
 }
 
+/** Shields.io `endpoint` badge schema (https://shields.io/badges/endpoint-badge). */
+export interface ShieldsBadge {
+	schemaVersion: 1;
+	label: string;
+	message: string;
+	color: string;
+}
+
+/** Shields badge colors per overall status (named colors shields understands). */
+const SHIELDS_COLOR: Record<StatusLevel, string> = { up: "brightgreen", degraded: "yellow", down: "red", unknown: "lightgrey" };
+
+/**
+ * Render a {@link StatusSummary} as a shields.io endpoint badge, so the README
+ * (and any other embed) can show a live, status-colored badge served straight
+ * from `/api/summary?format=shields` — giving the rollup a real consumer.
+ */
+export function shieldsBadge(summary: StatusSummary): ShieldsBadge {
+	return { schemaVersion: 1, label: "isUpMap", message: summary.message, color: SHIELDS_COLOR[summary.status] };
+}
+
 /** Roll a snapshot up into a single overall status + headline. */
 export function summarize(snapshot: Snapshot): StatusSummary {
 	const counts: Record<StatusLevel, number> = { up: 0, degraded: 0, down: 0, unknown: 0 };
@@ -217,10 +237,14 @@ export default {
 
 		if (url.pathname === "/api/summary") {
 			// Overall-status rollup for compact embeds (favicon/title, badges,
-			// "All systems operational" banners). Same D1-read/live-fallback and
-			// per-colo caching as /api/status.
+			// "All systems operational" banners). `?format=shields` returns a
+			// shields.io endpoint badge (powers the README badge); the default is
+			// the full JSON rollup. Same D1-read/live-fallback and per-colo caching
+			// as /api/status.
+			const shields = url.searchParams.get("format") === "shields";
 			const cache = caches.default;
-			const cacheKey = new Request(new URL("/api/summary", url.origin).toString(), { method: "GET" });
+			// Keep the format in the cache key so the JSON and badge variants don't collide.
+			const cacheKey = new Request(new URL(`/api/summary${shields ? "?format=shields" : ""}`, url.origin).toString(), { method: "GET" });
 			const hit = await cache.match(cacheKey);
 			if (hit) return hit;
 
@@ -228,7 +252,8 @@ export default {
 			if (limited) return limited;
 
 			const { snapshot, fromDb } = await loadSnapshot(env);
-			const resp = json(summarize(snapshot));
+			const summary = summarize(snapshot);
+			const resp = json(shields ? shieldsBadge(summary) : summary);
 			const cacheable = fromDb || snapshot.services.some((s) => s.status !== "unknown");
 			if (cacheable) ctx.waitUntil(cache.put(cacheKey, resp.clone()));
 			return resp;

--- a/test/summary.test.ts
+++ b/test/summary.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { summarize } from "../src/index";
+import { shieldsBadge, summarize } from "../src/index";
 import type { ApiService } from "../src/db";
 import type { StatusLevel } from "../src/services";
 
@@ -51,5 +51,18 @@ describe("summarize", () => {
 	it("passes through updatedAt", () => {
 		expect(summarize(snapshot(["up"], 42)).updatedAt).toBe(42);
 		expect(summarize(snapshot(["up"], null)).updatedAt).toBeNull();
+	});
+});
+
+describe("shieldsBadge", () => {
+	it("emits the shields endpoint schema with the rollup headline", () => {
+		const badge = shieldsBadge(summarize(snapshot(["up", "up"])));
+		expect(badge).toEqual({ schemaVersion: 1, label: "isUpMap", message: "All systems operational", color: "brightgreen" });
+	});
+
+	it("colors the badge by overall status", () => {
+		expect(shieldsBadge(summarize(snapshot(["up", "degraded"]))).color).toBe("yellow");
+		expect(shieldsBadge(summarize(snapshot(["up", "down"]))).color).toBe("red");
+		expect(shieldsBadge(summarize(snapshot(["unknown"]))).color).toBe("lightgrey");
 	});
 });


### PR DESCRIPTION
## Why

`/api/summary` was a fully-built, tested, documented endpoint with **zero consumers** — the frontend computes its own status rollup independently. This gives it a real consumer: a live status badge in the README.

## What

- **`?format=shields`** on `/api/summary` returns a [shields.io endpoint badge](https://shields.io/badges/endpoint-badge) payload (`schemaVersion`/`label`/`message`/`color`), color-mapped by overall status (`brightgreen`/`yellow`/`red`/`lightgrey`). The default response is unchanged JSON.
- The colo **cache key now includes the format** so the JSON and badge variants don't collide.
- **README**: live badge at the top + endpoint docs for the new format.
- **Tests**: cover the badge schema and per-status colors.

The badge renders `isUpMap | All systems operational` in green and flips to yellow/red automatically when something degrades or goes down, since shields fetches the live endpoint server-side.

## Verification

- `npm run typecheck` — clean
- `npm test` — 64 passed (incl. 2 new `shieldsBadge` tests)

> Note: the badge image only renders once `isupmap.com/api/summary?format=shields` is deployed (shields fetches it server-side). The format logic itself is unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)