### PR TITLE
fix: parse RSS content:encoded body (PayPal classified as unknown)

### DIFF
--- a/src/sources.ts
+++ b/src/sources.ts
@@ -165,7 +165,7 @@ async function fetchStatuspage(service: Service, base: string): Promise<ServiceS
 
 interface FeedEntry {
 	title: string;
-	/** Raw entry body (RSS `description` / Atom `summary`|`content`); may contain HTML. */
+	/** Raw entry body (RSS `description`|`content:encoded` / Atom `summary`|`content`); may contain HTML. */
 	description: string;
 	date: number | null;
 	link: string | null;
@@ -196,8 +196,9 @@ function latestEntry(doc: unknown): FeedEntry | null {
 		const parsed = rawDate ? Date.parse(rawDate) : NaN;
 		const date = Number.isNaN(parsed) ? null : parsed;
 		const title = nodeText(item.title);
-		// RSS uses `description`; Atom uses `summary` or `content`.
-		const description = nodeText(item.description ?? item.summary ?? item.content);
+		// RSS uses `description` (or namespaced `content:encoded`, kept verbatim by the
+		// parser — e.g. PayPal); Atom uses `summary` or `content`.
+		const description = nodeText(item.description ?? item["content:encoded"] ?? item.summary ?? item.content);
 		// RSS link is a string; Atom link is an element with an href attribute.
 		const linkRaw = item.link;
 		const link = typeof linkRaw === "object" ? (linkRaw?.["@_href"] ?? null) : (linkRaw ?? null);

--- a/test/sources.test.ts
+++ b/test/sources.test.ts
@@ -207,6 +207,17 @@ describe("rss", () => {
 		expect((await resolve()).status).toBe("down");
 	});
 
+	it("reads the body from a namespaced content:encoded element (PayPal-style)", async () => {
+		// PayPal's feed carries the incident body in <content:encoded>, not <description>.
+		// The parser keeps the namespace prefix, so without that fallback the body is lost
+		// and a real incident collapses to the title-only path (here: a false 'unknown').
+		const body = "May 6 17:43 PDT Investigating - We are aware of a major outage affecting payments.";
+		const item = `<item><title>Service event (PP-LIVE-1)</title><content:encoded><![CDATA[${body}]]></content:encoded><pubDate>${now()}</pubDate><link>https://x/1</link></item>`;
+		const feed = `<?xml version="1.0" encoding="utf-8"?><rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/"><channel>${item}</channel></rss>`;
+		fetchSpy.mockResolvedValue(reply(feed));
+		expect((await resolve()).status).toBe("down");
+	});
+
 	it("is up when the latest entry is stale (outside the fresh window)", async () => {
 		fetchSpy.mockResolvedValue(reply(rss("Major outage", old())));
 		expect((await resolve()).status).toBe("up");


### PR DESCRIPTION
## Problem

PayPal's status feed (`https://www.paypal-status.com/feed/rss`) carries each incident body in a namespaced `<content:encoded>` element, not `<description>`. `fast-xml-parser` keeps the namespace prefix (key `content:encoded`), but `latestEntry` only read `description`/`summary`/`content` — so PayPal's body was always empty.

With an empty body, `classifyEntry` skips every body-based signal (the `Status:` line, stage markers, leading-keyword scan — the core of the classifier) and falls through to the title-only fallback:

- The current entry is a maintenance notice whose title matches no regex → PayPal resolved to a false **`unknown`**.
- This isn't maintenance-specific: a resolved incident whose title still reads "…Outage…" would classify as a false **`down`**, and active-incident severity would be guessed from the title alone.

Confirmed against the live feed: the latest item's keys are `['title','link','guid','pubDate','content:encoded']`, with `description`/`summary`/`content` all `undefined`.

## Fix

Add `content:encoded` to the body fallback chain in `latestEntry`, after `description` and before the Atom keys:

```js
const description = nodeText(item.description ?? item["content:encoded"] ?? item.summary ?? item.content);
```

`content:encoded` is standard RSS, so the change is additive (no behavior change for the other 21 RSS feeds) and any other feed using it now benefits too.

## Test

Added a PayPal-style case to `test/sources.test.ts` — a feed with the body in `<content:encoded>` and an active outage — asserting `down` (was `unknown` before the fix).

- `npx vitest run test/sources.test.ts` → 41/41 pass
- `npm run typecheck` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)