### PR TITLE
feat(legal): add Terms of Service and Privacy Policy

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -328,6 +328,12 @@
 
 		<div id="toasts" class="toasts" aria-live="assertive" aria-atomic="false"></div>
 
+		<footer class="site-footer">
+			<a href="/terms">Terms</a>
+			<span aria-hidden="true">&middot;</span>
+			<a href="/privacy">Privacy</a>
+		</footer>
+
 		<script src="/app.js" type="module"></script>
 	</body>
 </html>

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -1,0 +1,185 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Privacy Policy — isUpMap</title>
+<meta name="description" content="Privacy Policy for isUpMap — what data we collect, how we use it, and your rights." />
+<link rel="canonical" href="https://isupmap.com/privacy" />
+<meta name="robots" content="index, follow" />
+<meta name="theme-color" content="#0f1117" />
+<meta property="og:type" content="website" />
+<meta property="og:title" content="Privacy Policy — isUpMap" />
+<meta property="og:description" content="Privacy Policy for isUpMap — what data we collect, how we use it, and your rights." />
+<meta property="og:url" content="https://isupmap.com/privacy" />
+<meta property="og:site_name" content="isUpMap" />
+<meta property="og:image" content="https://isupmap.com/images/og-map.png" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="Privacy Policy — isUpMap" />
+<meta name="twitter:description" content="Privacy Policy for isUpMap — what data we collect, how we use it, and your rights." />
+<meta name="twitter:image" content="https://isupmap.com/images/og-map.png" />
+<link rel="icon" type="image/png" href="/images/logo/icon/favicon-32x32.png" />
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Privacy Policy — isUpMap","url":"https://isupmap.com/privacy","isPartOf":{"@id":"https://isupmap.com/#website"}}</script>
+<style>
+:root { color-scheme: dark; }
+* { box-sizing: border-box; }
+body { margin: 0; background: #0f1117; color: #e6edf3; font: 16px/1.6 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; }
+a { color: #58a6ff; text-decoration: none; }
+a:hover { text-decoration: underline; }
+.wrap { max-width: 760px; margin: 0 auto; padding: 32px 20px 64px; }
+.brand { display: inline-flex; align-items: center; gap: 8px; font-weight: 700; color: #e6edf3; }
+.brand img { width: 24px; height: 24px; }
+.crumbs { margin: 24px 0 8px; font-size: 13px; color: #8b949e; }
+h1 { font-size: clamp(22px, 4vw, 30px); line-height: 1.2; margin: 8px 0 4px; }
+.effective { font-size: 13px; color: #8b949e; margin: 0 0 32px; }
+h2 { font-size: 18px; margin: 32px 0 8px; color: #c9d1d9; border-bottom: 1px solid rgba(255,255,255,.08); padding-bottom: 6px; }
+p { margin: 0 0 14px; }
+ul { margin: 0 0 14px; padding-left: 24px; }
+li { margin-bottom: 6px; }
+table { width: 100%; border-collapse: collapse; margin: 0 0 18px; font-size: 14px; }
+th { text-align: left; padding: 8px 12px; background: rgba(255,255,255,.04); border: 1px solid rgba(255,255,255,.08); color: #c9d1d9; font-weight: 600; }
+td { padding: 8px 12px; border: 1px solid rgba(255,255,255,.08); vertical-align: top; }
+.note { background: rgba(255,255,255,.03); border: 1px solid rgba(255,255,255,.08); border-radius: 10px; padding: 14px 18px; margin: 16px 0; font-size: 14px; color: #8b949e; }
+footer { margin-top: 40px; padding-top: 14px; border-top: 1px solid rgba(255,255,255,.08); font-size: 12px; color: #8b949e; }
+footer a { color: #58a6ff; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <a class="brand" href="/"><img src="/images/logo/isupmap.png" alt="" width="24" height="24" />isUpMap</a>
+  <nav class="crumbs"><a href="/">Home</a> / Privacy Policy</nav>
+
+  <h1>Privacy Policy</h1>
+  <p class="effective">Effective date: June 8, 2026</p>
+
+  <p>This Privacy Policy describes how <strong>isUpMap</strong>, operated by Jairon Landa ("we", "us", or "our"), collects, uses, and protects information when you visit <a href="https://isupmap.com">isupmap.com</a>.</p>
+  <p>isUpMap is a free, read-only public service. We do not require accounts, logins, or any personal information to use the site.</p>
+
+  <h2>1. Information We Collect</h2>
+
+  <h3 style="font-size:15px;margin:20px 0 6px;color:#c9d1d9;">1a. Analytics (Google Analytics 4)</h3>
+  <p>We use Google Analytics 4 (GA4) on the production site to understand aggregate usage patterns. GA4 collects:</p>
+  <ul>
+    <li>Pages visited and time spent on the site</li>
+    <li>Approximate geographic location (country / region level, derived from IP by Google — the raw IP is not stored by us)</li>
+    <li>Browser type, device type, and operating system</li>
+    <li>Referrer URL</li>
+  </ul>
+  <p>Analytics is <strong>disabled on localhost and development environments</strong> — it runs only on the production domain. Data is processed by Google under their own <a href="https://policies.google.com/privacy" target="_blank" rel="noopener">Privacy Policy</a>. You can opt out using the <a href="https://tools.google.com/dlpage/gaoptout" target="_blank" rel="noopener">Google Analytics Opt-out Browser Add-on</a> or a browser extension that blocks tracking scripts.</p>
+
+  <h3 style="font-size:15px;margin:20px 0 6px;color:#c9d1d9;">1b. Community "Report It's Down" Submissions</h3>
+  <p>When you voluntarily submit a "Report it's down" signal for a service, we record:</p>
+
+  <table>
+    <thead>
+      <tr><th>Data point</th><th>What it is</th><th>Retention</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>IP hash</td>
+        <td>A one-way SHA-256 hash of your IP address combined with a server-side secret salt. Your raw IP address is <strong>never stored</strong>. The hash is used solely to enforce a one-report-per-IP deduplication window (24 hours per service).</td>
+        <td>30 days</td>
+      </tr>
+      <tr>
+        <td>Country code</td>
+        <td>Two-letter country code derived from the network request by Cloudflare (e.g. "US", "DE"). Used for the geographic breakdown on service pages.</td>
+        <td>30 days</td>
+      </tr>
+      <tr>
+        <td>Report reason</td>
+        <td>One of five categories you select: "Can't connect", "Errors", "Can't log in", "Slow", or "Something else".</td>
+        <td>30 days</td>
+      </tr>
+      <tr>
+        <td>Timestamp</td>
+        <td>When the report was submitted (Unix epoch, milliseconds).</td>
+        <td>30 days</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="note">We never store your raw IP address. The hash is a one-way transformation and cannot be used to reconstruct your IP. Reports are automatically deleted after 30 days.</div>
+
+  <h3 style="font-size:15px;margin:20px 0 6px;color:#c9d1d9;">1c. Infrastructure Logs (Cloudflare)</h3>
+  <p>isUpMap runs on Cloudflare Workers. Cloudflare may log request metadata (IP addresses, request paths, timestamps) as part of normal infrastructure operation. These logs are controlled by Cloudflare and subject to their <a href="https://www.cloudflare.com/privacypolicy/" target="_blank" rel="noopener">Privacy Policy</a>. We do not have access to raw Cloudflare infrastructure logs beyond what our own application code records.</p>
+
+  <h2>2. What We Do Not Collect</h2>
+  <ul>
+    <li>We do not collect names, email addresses, or any other contact information.</li>
+    <li>We do not require account creation or login.</li>
+    <li>We do not process payments or store financial information.</li>
+    <li>We do not use cookies for tracking or session management (the site has no login state).</li>
+    <li>We do not sell, rent, or share your data with third parties for advertising purposes.</li>
+  </ul>
+
+  <h2>3. How We Use Collected Information</h2>
+  <p>The limited data we collect is used to:</p>
+  <ul>
+    <li><strong>Display community reports</strong> — aggregate counts and country breakdowns are shown publicly on per-service status pages as a supplementary signal.</li>
+    <li><strong>Prevent spam</strong> — the hashed IP is used to enforce the one-report-per-IP-per-service-per-24h deduplication rule.</li>
+    <li><strong>Understand aggregate site usage</strong> — via GA4, to guide decisions about which services to add or how to improve the UI.</li>
+    <li><strong>Rate limit the API</strong> — IP addresses from incoming requests are used to enforce per-IP request limits. They are not logged or stored by our application code.</li>
+  </ul>
+
+  <h2>4. Data Retention</h2>
+  <ul>
+    <li>Community report records (IP hash, country, reason, timestamp) are automatically deleted after <strong>30 days</strong> by a daily maintenance sweep.</li>
+    <li>Service incident records (automated status transitions) are retained for <strong>90 days</strong>.</li>
+    <li>Google Analytics data is retained according to Google's standard retention settings.</li>
+  </ul>
+
+  <h2>5. Third-Party Services</h2>
+  <table>
+    <thead>
+      <tr><th>Service</th><th>Purpose</th><th>Privacy policy</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Google Analytics 4</td>
+        <td>Aggregate usage analytics</td>
+        <td><a href="https://policies.google.com/privacy" target="_blank" rel="noopener">policies.google.com/privacy</a></td>
+      </tr>
+      <tr>
+        <td>Cloudflare Workers / D1 / KV</td>
+        <td>Hosting, edge compute, and data storage</td>
+        <td><a href="https://www.cloudflare.com/privacypolicy/" target="_blank" rel="noopener">cloudflare.com/privacypolicy</a></td>
+      </tr>
+      <tr>
+        <td>Protomaps</td>
+        <td>Map tile provider for community report world maps</td>
+        <td><a href="https://protomaps.com/privacy" target="_blank" rel="noopener">protomaps.com/privacy</a></td>
+      </tr>
+    </tbody>
+  </table>
+  <p>Sponsor links in the site header point to third-party websites. We do not share any data with sponsors. Their privacy practices are governed by their own policies.</p>
+
+  <h2>6. Data Security</h2>
+  <p>We take reasonable technical measures to protect data:</p>
+  <ul>
+    <li>IP addresses are never stored in raw form — only as a keyed SHA-256 hash.</li>
+    <li>All traffic is served over HTTPS.</li>
+    <li>Community reports flow through a server-side queue before reaching the database, providing a buffer against direct injection attacks.</li>
+    <li>Database access is restricted to the Cloudflare Worker (no public database endpoint).</li>
+  </ul>
+
+  <h2>7. Children's Privacy</h2>
+  <p>isUpMap is not directed at children under 13. We do not knowingly collect personal information from children. If you believe a child has submitted information through the community report feature, please contact us and we will delete it promptly.</p>
+
+  <h2>8. Your Rights</h2>
+  <p>Because we do not collect identifiable personal information (raw IPs are never stored; reports are anonymous), we cannot link a report to a specific individual. If you are in a jurisdiction with data rights (such as GDPR or CCPA) and believe we hold data attributable to you, contact us and we will investigate.</p>
+
+  <h2>9. Changes to This Policy</h2>
+  <p>We may update this Privacy Policy from time to time. The "Effective date" at the top of this page reflects the latest revision. Continued use of the Service after any changes constitutes acceptance of the updated policy.</p>
+
+  <h2>10. Contact</h2>
+  <p>Questions about this Privacy Policy? Reach out via <a href="https://x.com/JaironDevNull" target="_blank" rel="noopener">@JaironDevNull on X</a> or open an issue on the <a href="https://github.com/Jaironlanda/isupmap" target="_blank" rel="noopener">GitHub repository</a>.</p>
+
+  <footer>
+    &copy; 2026 isUpMap &middot; Jairon Landa
+    &middot; <a href="/">Live status map</a>
+    &middot; <a href="/status">All services</a>
+    &middot; <a href="/terms">Terms of Service</a>
+  </footer>
+</div>
+</body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1697,3 +1697,27 @@ body {
 	color: var(--muted);
 	font-variant-numeric: tabular-nums;
 }
+
+/* Site footer — Terms / Privacy links */
+.site-footer {
+	flex: 0 0 auto;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 0.5rem;
+	padding: 0.35rem 1rem;
+	font-size: 0.6875rem;
+	color: var(--muted);
+	border-top: 1px solid var(--border);
+	background: var(--panel);
+}
+
+.site-footer a {
+	color: var(--muted);
+	text-decoration: none;
+}
+
+.site-footer a:hover {
+	color: var(--text);
+	text-decoration: underline;
+}

--- a/public/terms.html
+++ b/public/terms.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Terms of Service — isUpMap</title>
+<meta name="description" content="Terms of Service for isUpMap — a free, real-time service status heatmap." />
+<link rel="canonical" href="https://isupmap.com/terms" />
+<meta name="robots" content="index, follow" />
+<meta name="theme-color" content="#0f1117" />
+<meta property="og:type" content="website" />
+<meta property="og:title" content="Terms of Service — isUpMap" />
+<meta property="og:description" content="Terms of Service for isUpMap — a free, real-time service status heatmap." />
+<meta property="og:url" content="https://isupmap.com/terms" />
+<meta property="og:site_name" content="isUpMap" />
+<meta property="og:image" content="https://isupmap.com/images/og-map.png" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="Terms of Service — isUpMap" />
+<meta name="twitter:description" content="Terms of Service for isUpMap — a free, real-time service status heatmap." />
+<meta name="twitter:image" content="https://isupmap.com/images/og-map.png" />
+<link rel="icon" type="image/png" href="/images/logo/icon/favicon-32x32.png" />
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Terms of Service — isUpMap","url":"https://isupmap.com/terms","isPartOf":{"@id":"https://isupmap.com/#website"}}</script>
+<style>
+:root { color-scheme: dark; }
+* { box-sizing: border-box; }
+body { margin: 0; background: #0f1117; color: #e6edf3; font: 16px/1.6 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; }
+a { color: #58a6ff; text-decoration: none; }
+a:hover { text-decoration: underline; }
+.wrap { max-width: 760px; margin: 0 auto; padding: 32px 20px 64px; }
+.brand { display: inline-flex; align-items: center; gap: 8px; font-weight: 700; color: #e6edf3; }
+.brand img { width: 24px; height: 24px; }
+.crumbs { margin: 24px 0 8px; font-size: 13px; color: #8b949e; }
+h1 { font-size: clamp(22px, 4vw, 30px); line-height: 1.2; margin: 8px 0 4px; }
+.effective { font-size: 13px; color: #8b949e; margin: 0 0 32px; }
+h2 { font-size: 18px; margin: 32px 0 8px; color: #c9d1d9; border-bottom: 1px solid rgba(255,255,255,.08); padding-bottom: 6px; }
+p { margin: 0 0 14px; }
+ul { margin: 0 0 14px; padding-left: 24px; }
+li { margin-bottom: 6px; }
+.note { background: rgba(255,255,255,.03); border: 1px solid rgba(255,255,255,.08); border-radius: 10px; padding: 14px 18px; margin: 16px 0; font-size: 14px; color: #8b949e; }
+footer { margin-top: 40px; padding-top: 14px; border-top: 1px solid rgba(255,255,255,.08); font-size: 12px; color: #8b949e; }
+footer a { color: #58a6ff; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <a class="brand" href="/"><img src="/images/logo/isupmap.png" alt="" width="24" height="24" />isUpMap</a>
+  <nav class="crumbs"><a href="/">Home</a> / Terms of Service</nav>
+
+  <h1>Terms of Service</h1>
+  <p class="effective">Effective date: June 8, 2026</p>
+
+  <p>Welcome to <strong>isUpMap</strong> ("the Service"), operated by Jairon Landa ("we", "us", or "our"). By accessing or using <a href="https://isupmap.com">isupmap.com</a>, you agree to these Terms. If you do not agree, please do not use the Service.</p>
+
+  <h2>1. What isUpMap Is</h2>
+  <p>isUpMap is a free, read-only status aggregator. It polls publicly available status pages and HTTP endpoints for 80+ internet services and displays an at-a-glance heatmap of their current operational state. It is not affiliated with, endorsed by, or operated in partnership with any of the services it monitors.</p>
+
+  <h2>2. Informational Purpose Only</h2>
+  <p>All status information on isUpMap is provided <strong>for informational purposes only</strong>. Data is sourced from third-party status pages and automated HTTP probes and may lag, be inaccurate, or differ from the provider's own published status. Do not rely on isUpMap as the sole source of truth for production systems or critical infrastructure decisions.</p>
+  <div class="note">Status readings are best-effort estimates. Automated checks run approximately every 5 minutes. A brief outage may be missed; a transient network hiccup may be reported as a problem. Always consult the provider's official status page for authoritative information.</div>
+
+  <h2>3. Community Reports</h2>
+  <p>Users may voluntarily submit a "Report it's down" signal for a service. These community reports are <strong>supplementary signals only</strong> — they do not alter the automated status readings, open incidents, or represent isUpMap's assessment of a service. We do not verify the accuracy of user-submitted reports.</p>
+
+  <h2>4. Acceptable Use</h2>
+  <p>You agree not to:</p>
+  <ul>
+    <li>Abuse, overload, or attempt to circumvent the rate limits on the public API endpoints.</li>
+    <li>Use the Service in any way that violates applicable laws or regulations.</li>
+    <li>Submit automated or bulk community reports intended to manipulate displayed data.</li>
+    <li>Scrape or mirror the Service at a scale that degrades performance for other users.</li>
+    <li>Attempt to reverse-engineer, decompile, or interfere with the Service's backend infrastructure.</li>
+  </ul>
+  <p>We reserve the right to block access from IPs or networks that violate these terms without prior notice.</p>
+
+  <h2>5. Intellectual Property</h2>
+  <p>All service names, logos, and trademarks displayed on isUpMap are the property of their respective owners. Their inclusion on this site is purely for identification purposes and does not imply any endorsement or affiliation. The isUpMap name, logo, and original source code are owned by Jairon Landa. The source code is available on <a href="https://github.com/Jaironlanda/isupmap" target="_blank" rel="noopener">GitHub</a> under its stated license.</p>
+
+  <h2>6. Third-Party Links and Sponsors</h2>
+  <p>The Service may display links to third-party websites, including sponsor links. We are not responsible for the content, privacy practices, or reliability of any third-party sites. Sponsor relationships do not influence status data or reporting.</p>
+
+  <h2>7. No Warranties</h2>
+  <p>THE SERVICE IS PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED. WE DO NOT WARRANT THAT THE SERVICE WILL BE UNINTERRUPTED, ERROR-FREE, OR THAT THE STATUS DATA WILL BE ACCURATE OR TIMELY. YOUR USE OF THE SERVICE IS AT YOUR SOLE RISK.</p>
+
+  <h2>8. Limitation of Liability</h2>
+  <p>TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL JAIRON LANDA BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES ARISING FROM YOUR USE OF OR INABILITY TO USE THE SERVICE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. OUR TOTAL LIABILITY FOR ANY CLAIM ARISING OUT OF THESE TERMS SHALL NOT EXCEED USD $0, AS THE SERVICE IS PROVIDED FREE OF CHARGE.</p>
+
+  <h2>9. Changes to the Service and Terms</h2>
+  <p>We may modify, suspend, or discontinue the Service at any time without notice. We may also update these Terms at any time. Continued use of the Service after any changes constitutes your acceptance of the new Terms. The "Effective date" at the top of this page reflects the most recent revision.</p>
+
+  <h2>10. Governing Law</h2>
+  <p>These Terms are governed by and construed in accordance with applicable law. Any disputes shall be resolved in the courts of competent jurisdiction.</p>
+
+  <h2>11. Contact</h2>
+  <p>Questions about these Terms? Reach out via <a href="https://x.com/JaironDevNull" target="_blank" rel="noopener">@JaironDevNull on X</a> or open an issue on the <a href="https://github.com/Jaironlanda/isupmap" target="_blank" rel="noopener">GitHub repository</a>.</p>
+
+  <footer>
+    &copy; 2026 isUpMap &middot; Jairon Landa
+    &middot; <a href="/">Live status map</a>
+    &middot; <a href="/status">All services</a>
+    &middot; <a href="/privacy">Privacy Policy</a>
+  </footer>
+</div>
+</body>
+</html>

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -110,6 +110,7 @@ ${opts.body}
 <footer>
 isUpMap checks ${SERVICES.length}+ services every few minutes. Status reflects the latest automated probe and may lag the provider's own status page.
 &middot; <a href="/">Live status map</a> &middot; <a href="/status">All services</a>
+&middot; <a href="/terms">Terms</a> &middot; <a href="/privacy">Privacy</a>
 </footer>
 </div>`;
 
@@ -276,6 +277,7 @@ export function renderServicePage(service: Service, current: ApiService | null, 
       <footer>
         isUpMap checks ${SERVICES.length}+ services every few minutes. Status reflects the latest automated probe and may lag the provider's own page.
         &middot; <a href="/status">All services</a>
+        &middot; <a href="/terms">Terms</a> &middot; <a href="/privacy">Privacy</a>
       </footer>
     </div>
   </aside>`;
@@ -369,6 +371,8 @@ export function renderSitemap(): string {
 	const urls = [
 		{ loc: `${CANONICAL_ORIGIN}/`, changefreq: "hourly", priority: "1.0" },
 		{ loc: `${CANONICAL_ORIGIN}/status`, changefreq: "hourly", priority: "0.8" },
+		{ loc: `${CANONICAL_ORIGIN}/terms`, changefreq: "monthly", priority: "0.3" },
+		{ loc: `${CANONICAL_ORIGIN}/privacy`, changefreq: "monthly", priority: "0.3" },
 		...SERVICES.map((s) => ({ loc: `${CANONICAL_ORIGIN}/status/${s.id}`, changefreq: "hourly", priority: "0.6" })),
 	];
 	const body = urls

--- a/test/pages.test.ts
+++ b/test/pages.test.ts
@@ -84,8 +84,8 @@ describe("renderSitemap", () => {
 		expect(xml).toContain("<loc>https://isupmap.com/</loc>");
 		expect(xml).toContain("<loc>https://isupmap.com/status</loc>");
 		for (const s of SERVICES) expect(xml).toContain(`<loc>https://isupmap.com/status/${s.id}</loc>`);
-		// Well-formed: one <url> per entry (home + directory + every service).
+		// Well-formed: one <url> per entry (home + directory + terms + privacy + every service).
 		const urlCount = (xml.match(/<url>/g) ?? []).length;
-		expect(urlCount).toBe(SERVICES.length + 2);
+		expect(urlCount).toBe(SERVICES.length + 4);
 	});
 });


### PR DESCRIPTION
## Summary

- Adds `public/terms.html` and `public/privacy.html` as static assets served by Cloudflare
- Privacy Policy covers: GA4 analytics, community reports (hashed IP, country, reason — 30-day retention), Cloudflare/Protomaps as third-party processors, and a note that raw IPs are never stored
- Terms of Service covers: informational-only disclaimer, acceptable use / rate-limit abuse, trademark notice, no-warranty / liability limitation, and contact
- Footer links wired into: `public/index.html` (new `.site-footer` bar), all SSR pages via `layout()` in `pages.ts`, and the `/status/<id>` panel footer
- Both pages added to the XML sitemap with `monthly` changefreq

## Test plan

- [ ] Visit `/terms` and `/privacy` — pages render with correct dark styling and back-links
- [ ] Check footer on the main heatmap (`/`) shows Terms · Privacy links
- [ ] Check footer on `/status` directory and a `/status/<id>` page shows Terms · Privacy links
- [ ] Verify `/sitemap.xml` includes `https://isupmap.com/terms` and `https://isupmap.com/privacy`
- [ ] `npm run typecheck` passes (no new type errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)