### PR TITLE
fix(mobile): restore collapsed home view + add desktop notice

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -741,6 +741,39 @@ sidebarClose.addEventListener("click", () => closeSidebar());
 sidebarOverlay.addEventListener("click", () => closeSidebar());
 phoneMq.addEventListener("change", relocateChrome);
 
+// --- Phone-only "best on desktop" notice ----------------------------------
+// Shown once per browser on small screens; dismissal is remembered so we
+// don't nag on every visit.
+const MOBILE_NOTICE_KEY = "isupmap:mobileNoticeSeen";
+const mobileNotice = document.getElementById("mobileNotice");
+const mobileNoticeDismiss = document.getElementById("mobileNoticeDismiss");
+
+function dismissMobileNotice() {
+	if (!mobileNotice) return;
+	mobileNotice.hidden = true;
+	try {
+		localStorage.setItem(MOBILE_NOTICE_KEY, "1");
+	} catch {
+		/* storage unavailable (private mode); we'll just show it again next time */
+	}
+}
+
+function maybeShowMobileNotice() {
+	if (!mobileNotice || !phoneMq.matches) return;
+	let seen = false;
+	try {
+		seen = localStorage.getItem(MOBILE_NOTICE_KEY) === "1";
+	} catch {
+		/* storage unavailable; treat as not seen */
+	}
+	if (!seen) mobileNotice.hidden = false;
+}
+
+mobileNoticeDismiss?.addEventListener("click", dismissMobileNotice);
+mobileNotice?.addEventListener("click", (e) => {
+	if (e.target === mobileNotice) dismissMobileNotice(); // tap the backdrop to dismiss
+});
+
 // --- Problems-only filter -------------------------------------------------
 
 const problemsBtn = document.getElementById("problemsBtn");
@@ -1274,6 +1307,7 @@ window.addEventListener("resize", () => {
 
 lucide.createIcons();
 relocateChrome();
+maybeShowMobileNotice();
 applyTheme();
 syncProblemsBtn();
 syncNotifyToggle();

--- a/public/index.html
+++ b/public/index.html
@@ -326,6 +326,22 @@
 			</div>
 		</div>
 
+		<!-- Phone-only one-time notice: the treemap is denser/easier on a wider screen.
+		     Shown once per browser on small screens; dismissal is remembered in localStorage. -->
+		<div id="mobileNotice" class="mobile-notice" hidden>
+			<div class="mobile-notice__box" role="dialog" aria-modal="true" aria-labelledby="mobileNoticeTitle">
+				<div class="mobile-notice__icon" aria-hidden="true">
+					<i data-lucide="monitor"></i>
+				</div>
+				<h2 id="mobileNoticeTitle" class="mobile-notice__title">Best viewed on desktop</h2>
+				<p class="mobile-notice__text">
+					isUpMap packs 90+ services into a live heatmap. It works on phones, but
+					a wider screen shows the full map and incident details far more comfortably.
+				</p>
+				<button id="mobileNoticeDismiss" class="mobile-notice__btn" type="button">Got it</button>
+			</div>
+		</div>
+
 		<div id="toasts" class="toasts" aria-live="assertive" aria-atomic="false"></div>
 
 		<footer class="site-footer">

--- a/public/report.css
+++ b/public/report.css
@@ -279,7 +279,10 @@
     overflow: visible;
   }
 
-  html, body {
+  /* Only relax html/body sizing on the report page (which has .sp-wrap).
+     report.css is also loaded on the home page, where body must stay
+     `height:100dvh; overflow:hidden` so the flex:1 treemap fills the screen. */
+  html:has(.sp-wrap), body:has(.sp-wrap) {
     height: auto !important;
     overflow: visible !important;
   }

--- a/public/styles.css
+++ b/public/styles.css
@@ -1186,6 +1186,86 @@ body {
 }
 
 /* --- Toasts --- */
+/* --- Phone-only "best on desktop" notice --- */
+.mobile-notice {
+	position: fixed;
+	inset: 0;
+	z-index: 95;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 1.25rem;
+	background: rgba(0, 0, 0, 0.6);
+	animation: fade-in 0.18s ease;
+}
+.mobile-notice[hidden] {
+	display: none;
+}
+/* Only ever relevant on small screens; never show on tablet/desktop. */
+@media (min-width: 641px) {
+	.mobile-notice {
+		display: none !important;
+	}
+}
+.mobile-notice__box {
+	width: 100%;
+	max-width: 360px;
+	background: var(--panel);
+	border: 1px solid var(--border);
+	border-radius: 14px;
+	padding: 1.5rem 1.4rem;
+	text-align: center;
+	box-shadow: 0 24px 70px rgba(0, 0, 0, 0.6);
+	animation: sheet-up 0.22s ease;
+}
+.mobile-notice__icon {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 48px;
+	height: 48px;
+	margin-bottom: 0.9rem;
+	border-radius: 12px;
+	background: rgba(127, 127, 127, 0.1);
+	color: var(--text);
+}
+.mobile-notice__icon svg,
+.mobile-notice__icon i[data-lucide] {
+	width: 24px;
+	height: 24px;
+}
+.mobile-notice__title {
+	margin: 0 0 0.5rem;
+	font-size: 1.1rem;
+	font-weight: 700;
+	letter-spacing: -0.01em;
+}
+.mobile-notice__text {
+	margin: 0 0 1.25rem;
+	font-size: 0.85rem;
+	line-height: 1.5;
+	color: var(--muted);
+}
+.mobile-notice__btn {
+	width: 100%;
+	padding: 0.7rem 1rem;
+	border: none;
+	border-radius: 8px;
+	background: var(--up-hi);
+	color: #07210f;
+	font-size: 0.9rem;
+	font-weight: 700;
+	cursor: pointer;
+}
+.mobile-notice__btn:hover {
+	filter: brightness(1.05);
+}
+
+@keyframes fade-in {
+	from { opacity: 0; }
+	to   { opacity: 1; }
+}
+
 .toasts {
 	position: fixed;
 	right: 1rem;


### PR DESCRIPTION
## Problem

On screens ≤700px the home page treemap was **invisible** — the body collapsed to ~100px tall and the footer floated up right under the header, leaving an empty black void.

### Root cause

[`public/report.css`](public/report.css) is loaded on **both** the home page ([`index.html`](public/index.html)) and the `/status/:id` report page. Its mobile media query contained an unscoped, `!important` override:

```css
@media (max-width: 700px) {
  html, body { height: auto !important; overflow: visible !important; }
}
```

That rule is only meant for the report page's `.sp-wrap` two-column layout (so it can scroll naturally on mobile). But the `html, body` selector is global, so on the home page it stomped `body { height: 100dvh; overflow: hidden }`, collapsing the `flex: 1` treemap grid to **0px height**.

## Fix

- **Scope the override to report pages** via `:has(.sp-wrap)`, so the home page keeps its full-height flex layout on mobile. The report page (`.sp-wrap` is server-rendered in `src/pages.ts`) still scrolls as before.
- **Add a phone-only "Best viewed on desktop" dialog** — shown once per browser (remembered in `localStorage` under `isupmap:mobileNoticeSeen`) on screens ≤640px, dismissable via the button or backdrop tap, and force-hidden on larger screens.

## Verification

Reproduced and verified with headless Chrome under mobile emulation (390×844):

| | Before | After |
|---|---|---|
| Home body height | 101px (grid 0px) | 844px (grid 743px, treemap fills screen) |
| `/status/:id` mobile | scrolls | still scrolls (unchanged) |
| Desktop (1280×800) | n/a | full treemap, no dialog |

Dialog measured perfectly centered (left:20, right:370 in a 390px viewport, no horizontal overflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)