### PR TITLE
fix(services): use HTTP ping for DeepSeek

### DIFF
--- a/src/services.ts
+++ b/src/services.ts
@@ -147,8 +147,8 @@ export const SERVICES: Service[] = [
 	{ id: "cerebras", name: "Cerebras", category: "AI", weight: 4, source: { type: "statuspage", base: "https://status.cerebras.ai" } },
 	// Fireworks AI uses a custom status page — RSS is the reliable path.
 	{ id: "fireworksai", name: "Fireworks AI", category: "AI", weight: 4, source: { type: "rss", url: "https://status.fireworks.ai/feed.rss", statusUrl: "https://status.fireworks.ai" } },
-	// status.deepseek.com Statuspage JSON returns 525 (SSL handshake error) from Cloudflare edge — use the RSS feed instead.
-	{ id: "deepseek", name: "DeepSeek", category: "AI", weight: 7, source: { type: "rss", url: "https://status.deepseek.com/feed.rss", statusUrl: "https://status.deepseek.com" } },
+	// DeepSeek's status feed is currently unavailable — fall back to an HTTP ping of the status page.
+	{ id: "deepseek", name: "DeepSeek", category: "AI", weight: 7, source: { type: "http", url: "https://status.deepseek.com", statusUrl: "https://status.deepseek.com" } },
 	// Mistral AI uses a custom Checkly-powered status page (Nuxt app) with no open machine-readable feed — HTTP ping fallback.
 	{ id: "mistral", name: "Mistral AI", category: "AI", weight: 6, source: { type: "http", url: "https://status.mistral.ai", statusUrl: "https://status.mistral.ai" } },
 

--- a/test/sources.test.ts
+++ b/test/sources.test.ts
@@ -479,28 +479,33 @@ describe("Mistral AI (http)", () => {
 	});
 });
 
-describe("DeepSeek (RSS)", () => {
-	const feedUrl = "https://status.deepseek.com/feed.rss";
+describe("DeepSeek (http)", () => {
+	const pingUrl = "https://status.deepseek.com";
 	const statusUrl = "https://status.deepseek.com";
-	const resolve = () => resolveStatus(svc({ type: "rss", url: feedUrl, statusUrl }));
-	const now = () => new Date().toUTCString();
+	const deepseek: Service = {
+		id: "deepseek",
+		name: "DeepSeek",
+		category: "AI",
+		weight: 7,
+		source: { type: "http", url: pingUrl, statusUrl },
+	};
+	const resolve = () => resolveStatus(deepseek);
 
-	function deepseekRss(title: string, pubDate: string) {
-		return `<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"><channel><title>DeepSeek Status</title><link>${statusUrl}/</link><item><title>${title}</title><link>${statusUrl}/</link><pubDate>${pubDate}</pubDate><description>${title}</description></item></channel></rss>`;
-	}
-
-	it("is up when the latest entry indicates recovery", async () => {
-		fetchSpy.mockResolvedValue(reply(deepseekRss("All systems recovered", now())));
+	it("is up when the status page returns 200 (all clear)", async () => {
+		fetchSpy.mockResolvedValue(reply("<!DOCTYPE html><html>OK</html>", 200));
 		const r = await resolve();
 		expect(r.status).toBe("up");
+		// Pings the configured URL.
+		expect(fetchSpy.mock.calls[0][0]).toBe(pingUrl);
+		// statusUrl must be surfaced so "Visit status page" links correctly.
 		expect(r.details?.url).toBe(statusUrl);
 	});
 
-	it("is down when the latest entry indicates an outage", async () => {
-		fetchSpy.mockResolvedValue(reply(deepseekRss("API service disruption", now())));
+	it("is down when the status page returns 500 (server error)", async () => {
+		// Two calls: first attempt + one retry (both 5xx).
+		fetchSpy.mockResolvedValue(reply("Internal Server Error", 500));
 		const r = await resolve();
 		expect(r.status).toBe("down");
 		expect(r.details?.url).toBe(statusUrl);
-		expect(r.details?.incident?.name).toBe("API service disruption");
 	});
 });


### PR DESCRIPTION
## Summary
DeepSeek's status feed is currently unavailable. This switches the `deepseek` service from its RSS source to a plain HTTP ping of the status page.

## Changes
- [src/services.ts](src/services.ts): `deepseek` source changed from `rss` to `http` (pings `https://status.deepseek.com`).
- [test/sources.test.ts](test/sources.test.ts): replaced the DeepSeek RSS test with an HTTP-ping test (up on 200, down on 500), mirroring the Mistral AI pattern.

## Testing
- `npm run typecheck` ✅
- DeepSeek tests pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)