### PR TITLE
fix(seo): 301 trailing-slash /status URLs to canonical

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -437,16 +437,29 @@ export default {
 			return markup(renderSitemap(), "application/xml; charset=utf-8", { headers: { "cache-control": "public, max-age=3600" } });
 		}
 
+		// 301 the trailing-slash variant to the canonical /status so crawlers index
+		// a single URL (otherwise Search Console flags the slash form as
+		// "Alternate page with proper canonical tag"). Query string is preserved.
+		if (url.pathname === "/status/") {
+			return Response.redirect(new URL(`/status${url.search}`, url.origin).toString(), 301);
+		}
+
 		// Server-rendered status directory (good for crawl discovery + internal links).
-		if (url.pathname === "/status" || url.pathname === "/status/") {
+		if (url.pathname === "/status") {
 			return markup(renderStatusIndex(), "text/html; charset=utf-8", { headers: { "cache-control": "public, max-age=3600" } });
 		}
 
 		// Per-service SSR page: /status/<id>. Indexable content for "is X down?".
-		const serviceMatch = url.pathname.match(/^\/status\/([a-z0-9-]+)\/?$/);
+		const serviceMatch = url.pathname.match(/^\/status\/([a-z0-9-]+)(\/?)$/);
 		if (serviceMatch) {
 			const service = findService(serviceMatch[1]);
 			if (!service) return markup(renderNotFound(), "text/html; charset=utf-8", { status: 404 });
+
+			// 301 the trailing-slash variant (/status/<id>/) to the canonical
+			// /status/<id> so crawlers only ever index one URL per service.
+			if (serviceMatch[2]) {
+				return Response.redirect(new URL(`/status/${service.id}${url.search}`, url.origin).toString(), 301);
+			}
 
 			const cache = caches.default;
 			const cacheKey = new Request(new URL(`/status/${service.id}`, url.origin).toString(), { method: "GET" });

--- a/test/redirects.test.ts
+++ b/test/redirects.test.ts
@@ -1,0 +1,67 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { beforeAll, describe, expect, it } from "vitest";
+import worker from "../src/index";
+import schemaReportsSql from "../schema-reports.sql?raw";
+
+// Rendering a /status/<id> page reads community reports from REPORTS_DB, so the
+// schema must exist for the canonical (200) case to render.
+async function applySchema(sql: string) {
+	const statements = sql
+		.split(";")
+		.map((chunk) =>
+			chunk
+				.split("\n")
+				.filter((line) => !line.trim().startsWith("--"))
+				.join("\n")
+				.trim(),
+		)
+		.filter((s) => s.length > 0);
+	for (const stmt of statements) await env.REPORTS_DB.prepare(stmt).run();
+}
+
+beforeAll(() => applySchema(schemaReportsSql));
+
+/**
+ * The /status routes accept an optional trailing slash but the canonical URL
+ * has none. Serving both forms 200 makes Search Console flag the slash variant
+ * as "Alternate page with proper canonical tag", so the Worker 301-redirects
+ * the slash form to its canonical, no-slash URL.
+ */
+async function fetchNoRedirect(path: string): Promise<Response> {
+	const req = new Request(`http://localhost${path}`, { redirect: "manual" });
+	const ctx = createExecutionContext();
+	const res = await worker.fetch(req, env, ctx);
+	await waitOnExecutionContext(ctx);
+	return res;
+}
+
+describe("trailing-slash canonicalization", () => {
+	it("301s /status/ to /status", async () => {
+		const res = await fetchNoRedirect("/status/");
+		expect(res.status).toBe(301);
+		expect(res.headers.get("location")).toBe("http://localhost/status");
+	});
+
+	it("301s /status/<id>/ to /status/<id>", async () => {
+		const res = await fetchNoRedirect("/status/github/");
+		expect(res.status).toBe(301);
+		expect(res.headers.get("location")).toBe("http://localhost/status/github");
+	});
+
+	it("preserves the query string when redirecting", async () => {
+		const res = await fetchNoRedirect("/status/github/?utm_source=x");
+		expect(res.status).toBe(301);
+		expect(res.headers.get("location")).toBe("http://localhost/status/github?utm_source=x");
+	});
+
+	it("serves the canonical /status/<id> form directly (no redirect)", async () => {
+		const res = await fetchNoRedirect("/status/github");
+		expect(res.status).toBe(200);
+		expect(res.headers.get("content-type")).toContain("text/html");
+	});
+
+	it("404s an unknown service even with a trailing slash", async () => {
+		const res = await fetchNoRedirect("/status/not-a-real-service/");
+		expect(res.status).toBe(404);
+	});
+});


### PR DESCRIPTION
## Problem

Google Search Console flagged pages as **"Alternate page with proper canonical tag"** — they weren't being indexed. The cause: the Worker served `200 OK` for *both* the canonical and trailing-slash forms of the `/status` routes (`/status/<id>` and `/status/<id>/` both rendered the same page with the same canonical), so Google treated the slash variants as duplicates of the canonical and skipped them.

## Change

- `/status/` → `301` → `/status`
- `/status/<id>/` → `301` → `/status/<id>`

Query strings are preserved on redirect; unknown service ids still return `404` (no redirect). Crawlers now only ever see one indexable URL per page.

## Tests

New `test/redirects.test.ts` covers both redirects, query-string preservation, the canonical `200`, and the unknown-id `404`. Full suite: 111 passing, typecheck clean.

## Follow-ups (outside this repo)

- If `www.isupmap.com` resolves, add a Cloudflare **Redirect Rule** `www` → apex (dashboard, not code).
- Confirm the canonical `/status/<id>` URLs show as **Indexed** in Search Console; use **Validate Fix** on the report after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)