### PR TITLE
Report-surge detection + Downdetector-style charts and "Reported" status

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,17 @@ and a mobile-friendly detail sheet.
   reason (`Can't connect`, `Errors`, `Can't log in`, `Slow`, `Other`). Votes are
   deduplicated per IP-hash per 24 h, buffered through a Cloudflare Queue, and
   persisted in a separate D1. The per-service detail page shows aggregate counts,
-  a 7-day volume chart, per-country and per-reason breakdowns, and a
+  a **24-hour report-volume chart** (Downdetector-style line + faint area over a
+  shaded "typical range" band), per-country and per-reason breakdowns, and a
   **Protomaps world map** of recent report origins.
+- **Report-surge detection** — a Downdetector-style anomaly signal layered on the
+  community reports. Each cron run scores a service's recent report volume against
+  its own rolling baseline (EWMA mean + variance) and raises a **surge** when the
+  count is a statistical outlier (≥3σ), clears an absolute floor (≥5 reports), and
+  holds for 2 consecutive passes. A surging service is shown as a new **"Reported"**
+  status color (orange) and a **24h sparkline** on big tiles — supplementary only,
+  it never opens an incident or alters the authoritative probe status. See
+  [`detectSurges`](src/reports.ts).
 - **Command palette (⌘K)** — fuzzy-search services and run commands.
 - **Local customization** — show/hide services or categories and a
   "problems only" filter, persisted in `localStorage`.
@@ -50,6 +59,8 @@ Cron (every 5m) ─▶ scheduled() ─▶ resolveStatus() × N      ┌─▶ St
                        │                                          (service id, url, latency, status code, attempt)
                        ├─▶ persist to D1 (src/db.ts): flap-dampen → upsert `current`,
                        │   open/close `incidents`; daily retention sweep
+                       ├─▶ decorateReports() — surge detection + 24h sparkline from REPORTS_DB
+                       │   (supplementary; failure never blocks the status snapshot)
                        └─▶ publish finished snapshot to KV (SNAPSHOT_KV)
 Browser (public/) ─poll /api/status every 45s─▶ Worker reads KV (Cache-API fronted) ─▶ treemap + uptime
                   └─open detail / panel ───────▶ GET /api/incidents (D1, cached)     ─▶ incident history
@@ -60,7 +71,8 @@ User taps "Report it's down" ─▶ POST /api/report/:id (VOTE_RATE_LIMITER: 10/
                                         └─▶ queue consumer → batch-insert into REPORTS_DB (D1)
 GET /api/report/:id ─▶ KV hit (10-min TTL) → or D1 aggregate query → report JSON
                                                                        (total, countries, reasons,
-                                                                        recent 10, 7-day timeline)
+                                                                        recent 10, 7-day timeline,
+                                                                        24h hourly series, surge flag)
 /status/:id page ─▶ server-rendered with Protomaps world map (report locations) + analytics panel
 ```
 
@@ -79,7 +91,9 @@ GET /api/report/:id ─▶ KV hit (10-min TTL) → or D1 aggregate query → rep
   query on the hot path), with per-service **uptime (24h / 7d)**. It's fronted by
   the **Cache API**; before the first cron run it serves a "warming" snapshot
   (never a live fan-out). The response carries a `stale` flag (older than 3 cron
-  cycles) so the UI warns instead of showing frozen data.
+  cycles) so the UI warns instead of showing frozen data. Each service also carries
+  a supplementary `surge` flag and a 24h report-volume `spark` series (added by the
+  cron) that the UI uses for the **"Reported"** tile color and per-tile sparkline.
 - `GET /api/incidents` returns the recent incident log from D1 (Cache-API fronted). An
   optional `?service=<id>` filter scopes it to a single service.
 - `POST /api/report/:id` accepts a community down-report (`{ reason }`) for a known service.
@@ -87,8 +101,9 @@ GET /api/report/:id ─▶ KV hit (10-min TTL) → or D1 aggregate query → rep
   24 h, and enqueued to `VOTE_QUEUE` for async batch-insert into `REPORTS_DB`. Tighter rate
   limit: 10 req / 60s per IP (`VOTE_RATE_LIMITER`). Returns `503` if `VOTE_SALT` is not set.
 - `GET /api/report/:id` returns aggregated community-report data for a service: 7-day total,
-  per-country and per-reason breakdowns, up to 10 most-recent individual reports, and a
-  7-day daily volume timeline. Cached in `SNAPSHOT_KV` (`reportcount:<id>`) with a 10-min TTL.
+  per-country and per-reason breakdowns, up to 10 most-recent individual reports, a 7-day daily
+  volume timeline, a **24h hourly series** (for the report-volume chart), and the current **surge**
+  flag. Cached in `SNAPSHOT_KV` (`reportcount:<id>`) with a 10-min TTL.
 - `GET /api/summary` returns a single **overall-status rollup** (worst status
   wins) plus a headline (`"All systems operational"` / `"2 down, 1 degraded"`),
   per-status counts, and the same `stale` flag — handy for compact embeds, badges,
@@ -121,6 +136,12 @@ Every service is normalized to one of: `up` · `degraded` · `down` · `unknown`
 > Statuspage JSON is authoritative where available. RSS-based status is a
 > best-effort heuristic, since incident feeds describe history rather than a
 > current-state field.
+
+There is also a **display-only** fifth state, **`reported`** (orange): shown when
+the probe says `up`/`unknown` but community reports are surging (see
+[Report-surge detection](#features)). It's derived at render time from the `surge`
+flag and **never** replaces a service's real `status` — a confirmed `down`/`degraded`
+always wins, and incidents and uptime stay 100% probe-driven.
 
 ## Data sources
 
@@ -448,9 +469,9 @@ src/
   analytics.ts       logFetch() helper — writes per-attempt fetch events to the Analytics Engine dataset
   db.ts              D1 persistence: flap-dampening, snapshot upserts, incident transitions, uptime, retention
   pages.ts           Server-rendered status pages (/status, /status/<id>) + sitemap.xml
-  reports.ts         Community report write/read/aggregate logic (REPORTS_DB + SNAPSHOT_KV cache)
+  reports.ts         Community report logic: write/read/aggregate, 24h sparkline + surge detection (REPORTS_DB + SNAPSHOT_KV cache)
 schema.sql           D1 schema (current / incidents / meta / probe_state) + indexes
-schema-reports.sql   D1 schema for REPORTS_DB (reports table + index)
+schema-reports.sql   D1 schema for REPORTS_DB (reports + report_baseline tables + index)
 wrangler.jsonc       Worker config (main, assets, cron, D1 × 2, KV, Queues, rate limits × 2, Analytics Engine)
 ```
 

--- a/public/app.js
+++ b/public/app.js
@@ -131,9 +131,12 @@ function renderView() {
 				? "✓ All selected services are operational"
 				: "No services selected — open Customize to add some.";
 		gridEl.innerHTML = `<p class="grid__empty">${escapeHtml(msg)}</p>`;
-		gridEl.classList.remove("grid--focus");
+		gridEl.classList.remove("grid--focus", "grid--solo");
 		return;
 	}
+	// Solo view (e.g. customized down to one service): the lone tile fills the
+	// grid, so let the sparkline scale up instead of staying capped + tiny.
+	gridEl.classList.toggle("grid--solo", v.length === 1);
 	render(v);
 }
 

--- a/public/app.js
+++ b/public/app.js
@@ -347,6 +347,16 @@ function renderTile(rect) {
 		status.textContent = STATUS_LABEL[svc.status] ?? svc.status;
 		tile.appendChild(status);
 	}
+
+	// Community-report surge: a corner badge when an anomalous number of users
+	// are reporting problems. Overlay only — never changes the tile color.
+	if (svc.surge) {
+		const surge = document.createElement("div");
+		surge.className = "tile__surge";
+		surge.title = "Users are reporting problems";
+		surge.setAttribute("aria-label", "Users are reporting problems");
+		tile.appendChild(surge);
+	}
 	return tile;
 }
 
@@ -1203,6 +1213,15 @@ function renderDetailHeader(svc) {
 		</a>`
 		: "";
 
+	// Surge banner: shown when community reports are spiking above this service's
+	// normal volume. A user-perceived signal, distinct from the official status.
+	const surgeHtml = svc.surge
+		? `<div class="detail__surge" role="status">
+				<span class="detail__surge-icon" aria-hidden="true">📈</span>
+				<span>Users are reporting problems — report volume is spiking above normal.</span>
+			</div>`
+		: "";
+
 	detailBody.innerHTML = `
 		<p class="detail__question">Is ${escapeHtml(svc.name)} down?</p>
 		<div class="detail__svc-card" style="--ds:${statusVar}">
@@ -1222,6 +1241,7 @@ function renderDetailHeader(svc) {
 			${noteHtml}
 			${extLinkHtml}
 		</div>
+		${surgeHtml}
 		<div class="detail__report-card">
 			<div data-report-widget data-service-id="${escapeHtml(svc.id)}"></div>
 		</div>

--- a/public/app.js
+++ b/public/app.js
@@ -13,6 +13,9 @@ const STATUS_LABEL = {
 	reported: "Reported",
 };
 
+/** Hover-tooltip text on the "Reported" status indicator (dialog beat). */
+const SURGE_TIP = "Users are reporting problems — volume is spiking above normal.";
+
 /**
  * Display-only status: folds the community-report surge into the color a service
  * is shown with, WITHOUT touching `svc.status` (which still drives incidents and
@@ -1269,7 +1272,7 @@ function renderDetailHeader(svc) {
 				<div class="detail__svc-main">
 					<div class="detail__svc-top">
 						<span class="detail__svc-name">${escapeHtml(svc.name)}</span>
-						<span class="detail__beat detail__beat--${effStatus}">
+						<span class="detail__beat detail__beat--${effStatus}"${effStatus === "reported" ? ` title="${SURGE_TIP}"` : ""}>
 							<span class="detail__beat-label">${STATUS_LABEL[effStatus]}</span>
 							<span class="detail__beat-dot" aria-hidden="true"></span>
 						</span>

--- a/public/app.js
+++ b/public/app.js
@@ -10,7 +10,19 @@ const STATUS_LABEL = {
 	degraded: "Degraded",
 	down: "Down",
 	unknown: "Unknown",
+	reported: "Reported",
 };
+
+/**
+ * Display-only status: folds the community-report surge into the color a service
+ * is shown with, WITHOUT touching `svc.status` (which still drives incidents and
+ * uptime). A real outage always dominates — surge only colors an otherwise
+ * up/unknown service as "reported" (users complaining, probe still fine).
+ */
+function effectiveStatus(svc) {
+	if (svc.surge && (svc.status === "up" || svc.status === "unknown")) return "reported";
+	return svc.status;
+}
 
 // Brand domain per service id. Logos are self-hosted (see logoUrl); this map
 // doubles as the "has a logo" gate and a record of each service's domain.
@@ -104,7 +116,7 @@ function visibleServices() {
 	// Disabled services (unreliable source) are never tiled — they only appear,
 	// locked, in the Customize panel.
 	let v = latest.filter((s) => !s.disabled && !prefs.hidden.has(s.id));
-	if (prefs.problemsOnly) v = v.filter((s) => s.status !== "up");
+	if (prefs.problemsOnly) v = v.filter((s) => effectiveStatus(s) !== "up");
 	return v;
 }
 
@@ -313,7 +325,7 @@ function renderSector(rect) {
 function renderTile(rect) {
 	const svc = rect.data;
 	const tile = document.createElement("article");
-	tile.className = `tile is-${svc.status}${svc.id === highlightId ? " tile--flash" : ""}`;
+	tile.className = `tile is-${effectiveStatus(svc)}${svc.id === highlightId ? " tile--flash" : ""}`;
 	setBox(tile, rect.x, rect.y, rect.w, rect.h, TILE_GAP / 2);
 	tile._svc = svc; // stash data for the hover card
 
@@ -344,20 +356,47 @@ function renderTile(rect) {
 		const status = document.createElement("div");
 		status.className = "tile__status";
 		status.style.fontSize = `${clamp(nameSize * 0.55, 9, 14)}px`;
-		status.textContent = STATUS_LABEL[svc.status] ?? svc.status;
+		status.textContent = STATUS_LABEL[effectiveStatus(svc)] ?? svc.status;
 		tile.appendChild(status);
 	}
 
-	// Community-report surge: a corner badge when an anomalous number of users
-	// are reporting problems. Overlay only — never changes the tile color.
-	if (svc.surge) {
-		const surge = document.createElement("div");
-		surge.className = "tile__surge";
-		surge.title = "Users are reporting problems";
-		surge.setAttribute("aria-label", "Users are reporting problems");
-		tile.appendChild(surge);
+	// Community-report sparkline: a 24h report-volume trend line along the bottom
+	// of big tiles (Downdetector-style). Small tiles have no room, so render
+	// nothing. Overlay only — never changes the tile color; turns surge-colored
+	// when an anomalous number of users are reporting problems.
+	const bigEnough = rect.h >= 84 && rect.w >= 110;
+	if (bigEnough && Array.isArray(svc.spark) && svc.spark.length > 1) {
+		const spark = document.createElement("div");
+		spark.className = "tile__spark";
+		spark.innerHTML = sparklineSvg(svc.spark, !!svc.surge);
+		if (svc.surge) {
+			spark.title = "Users are reporting problems";
+			spark.setAttribute("aria-label", "Users are reporting problems");
+		} else {
+			spark.setAttribute("aria-hidden", "true");
+		}
+		tile.appendChild(spark);
 	}
 	return tile;
+}
+
+/** Build an SVG report-volume sparkline (line + faint area) from a count series. */
+function sparklineSvg(values, surging) {
+	const n = values.length;
+	const max = Math.max(...values, 1);
+	const PAD = 6; // top padding (viewBox units) so peaks aren't clipped
+	const line = values
+		.map((v, i) => {
+			const x = n <= 1 ? 0 : (i / (n - 1)) * 100;
+			const y = 100 - PAD - (v / max) * (100 - PAD);
+			return `${x.toFixed(1)},${y.toFixed(1)}`;
+		})
+		.join(" ");
+	const cls = surging ? "tile__spark-svg is-surging" : "tile__spark-svg";
+	return `<svg class="${cls}" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
+		<polygon class="tile__spark-area" points="0,100 ${line} 100,100" />
+		<polyline class="tile__spark-line" points="${line}" />
+	</svg>`;
 }
 
 /** Position an absolutely-placed box, inset by `inset` px on every side for the gap. */
@@ -880,8 +919,8 @@ function buildPaletteItems(query) {
 		.sort((a, b) => a.name.localeCompare(b.name))
 		.map((s) => ({
 			label: s.name,
-			hint: `${s.category} · ${STATUS_LABEL[s.status]}`,
-			status: s.status,
+			hint: `${s.category} · ${STATUS_LABEL[effectiveStatus(s)]}`,
+			status: effectiveStatus(s),
 			kind: "service",
 			run: () => focusService(s.id),
 		}));
@@ -973,7 +1012,7 @@ function onSpotlightOutside(e) {
 function focusService(id) {
 	prefs.hidden.delete(id);
 	const svc = latest?.find((s) => s.id === id);
-	if (prefs.problemsOnly && svc && svc.status === "up") prefs.problemsOnly = false;
+	if (prefs.problemsOnly && svc && effectiveStatus(svc) === "up") prefs.problemsOnly = false;
 	savePrefs();
 	syncProblemsBtn();
 	highlightId = id;
@@ -1016,6 +1055,7 @@ const faviconEl = document.getElementById("favicon");
 function worstStatus(services) {
 	if (services.some((s) => s.status === "down")) return "down";
 	if (services.some((s) => s.status === "degraded")) return "degraded";
+	if (services.some((s) => effectiveStatus(s) === "reported")) return "reported";
 	return "up";
 }
 
@@ -1030,7 +1070,7 @@ function updateChrome(services) {
 
 	updateStatusbar(services);
 
-	const color = { up: "#40c057", degraded: "#f0b429", down: "#fa5252" }[worstStatus(services)];
+	const color = { up: "#40c057", reported: "#f0883e", degraded: "#f0b429", down: "#fa5252" }[worstStatus(services)];
 	const canvas = document.createElement("canvas");
 	canvas.width = canvas.height = 32;
 	const ctx = canvas.getContext("2d");
@@ -1048,15 +1088,17 @@ const statusSummaryDot = statusSummaryEl?.querySelector(".statusbar__dot");
 const statusSummaryText = document.getElementById("statusSummaryText");
 const legendCountEls = {
 	up: document.querySelector('[data-count="up"]'),
+	reported: document.querySelector('[data-count="reported"]'),
 	degraded: document.querySelector('[data-count="degraded"]'),
 	down: document.querySelector('[data-count="down"]'),
 	unknown: document.querySelector('[data-count="unknown"]'),
 };
 
 function updateStatusbar(services) {
-	const counts = { up: 0, degraded: 0, down: 0, unknown: 0 };
+	const counts = { up: 0, reported: 0, degraded: 0, down: 0, unknown: 0 };
 	for (const s of services) {
-		counts[s.status] = (counts[s.status] ?? 0) + 1;
+		const st = effectiveStatus(s);
+		counts[st] = (counts[st] ?? 0) + 1;
 	}
 
 	for (const [status, el] of Object.entries(legendCountEls)) {
@@ -1071,7 +1113,7 @@ function updateStatusbar(services) {
 		statusSummaryDot.className = `statusbar__dot is-${worst}`;
 	}
 	if (statusSummaryText) {
-		const issues = counts.down + counts.degraded;
+		const issues = counts.down + counts.degraded + counts.reported;
 		if (services.length === 0) {
 			statusSummaryText.textContent = "No services selected";
 		} else if (issues === 0) {
@@ -1080,13 +1122,14 @@ function updateStatusbar(services) {
 			const parts = [];
 			if (counts.down) parts.push(`${counts.down} down`);
 			if (counts.degraded) parts.push(`${counts.degraded} degraded`);
+			if (counts.reported) parts.push(`${counts.reported} reported`);
 			statusSummaryText.textContent = parts.join(" · ");
 		}
 	}
 
 	// When there are issues, the pill toggles the Problems-only filter; otherwise
 	// it's purely informational.
-	const hasIssues = counts.down + counts.degraded > 0;
+	const hasIssues = counts.down + counts.degraded + counts.reported > 0;
 	statusSummaryEl.disabled = !hasIssues && !prefs.problemsOnly;
 	statusSummaryEl.classList.toggle("is-active", prefs.problemsOnly);
 }
@@ -1181,6 +1224,7 @@ async function openDetail(svc) {
 // CSS variable name per status — used for the tinted service card (--ds).
 const DETAIL_STATUS_VAR = {
 	up: "var(--up-hi)",
+	reported: "var(--reported-hi)",
 	degraded: "var(--degraded-hi)",
 	down: "var(--down-hi)",
 	unknown: "var(--muted)",
@@ -1188,7 +1232,8 @@ const DETAIL_STATUS_VAR = {
 
 function renderDetailHeader(svc) {
 	const d = svc.details ?? {};
-	const statusVar = DETAIL_STATUS_VAR[svc.status] ?? "var(--muted)";
+	const effStatus = effectiveStatus(svc);
+	const statusVar = DETAIL_STATUS_VAR[effStatus] ?? "var(--muted)";
 
 	// Note shown inside the card: prefer the active incident name, fall back to description.
 	const noteText = d.incident
@@ -1213,15 +1258,6 @@ function renderDetailHeader(svc) {
 		</a>`
 		: "";
 
-	// Surge banner: shown when community reports are spiking above this service's
-	// normal volume. A user-perceived signal, distinct from the official status.
-	const surgeHtml = svc.surge
-		? `<div class="detail__surge" role="status">
-				<span class="detail__surge-icon" aria-hidden="true">📈</span>
-				<span>Users are reporting problems — report volume is spiking above normal.</span>
-			</div>`
-		: "";
-
 	detailBody.innerHTML = `
 		<p class="detail__question">Is ${escapeHtml(svc.name)} down?</p>
 		<div class="detail__svc-card" style="--ds:${statusVar}">
@@ -1230,8 +1266,8 @@ function renderDetailHeader(svc) {
 				<div class="detail__svc-main">
 					<div class="detail__svc-top">
 						<span class="detail__svc-name">${escapeHtml(svc.name)}</span>
-						<span class="detail__beat detail__beat--${svc.status}">
-							<span class="detail__beat-label">${STATUS_LABEL[svc.status]}</span>
+						<span class="detail__beat detail__beat--${effStatus}">
+							<span class="detail__beat-label">${STATUS_LABEL[effStatus]}</span>
 							<span class="detail__beat-dot" aria-hidden="true"></span>
 						</span>
 					</div>
@@ -1241,7 +1277,6 @@ function renderDetailHeader(svc) {
 			${noteHtml}
 			${extLinkHtml}
 		</div>
-		${surgeHtml}
 		<div class="detail__report-card">
 			<div data-report-widget data-service-id="${escapeHtml(svc.id)}"></div>
 		</div>
@@ -1259,7 +1294,7 @@ function renderDetailHeader(svc) {
 	else logoEl.remove();
 
 	// Tint the modal top border to reflect service status.
-	detailEl.querySelector(".modal__box").className = `modal__box is-${svc.status}`;
+	detailEl.querySelector(".modal__box").className = `modal__box is-${effStatus}`;
 
 	// Render Lucide icons injected by the template.
 	const newIcons = [...detailBody.querySelectorAll("i[data-lucide]")];

--- a/public/index.html
+++ b/public/index.html
@@ -205,6 +205,11 @@
 					<span class="legend__label">Up</span>
 					<span class="legend__count" data-count="up">—</span>
 				</li>
+				<li class="legend__item" data-status="reported">
+					<span class="swatch is-reported"></span>
+					<span class="legend__label">Reported</span>
+					<span class="legend__count" data-count="reported">—</span>
+				</li>
 				<li class="legend__item" data-status="degraded">
 					<span class="swatch is-degraded"></span>
 					<span class="legend__label">Degraded</span>

--- a/public/report.css
+++ b/public/report.css
@@ -416,35 +416,6 @@
 }
 
 /* Donut + legend */
-/* Surge banner: community reports spiking above normal. Warm amber (off the
-   green/amber/red status palette and not the old violet). Rendered inside the
-   report widget so the detail dialog and /status page share one design. */
-.report-surge {
-  box-sizing: border-box;
-  width: 100%;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin: 0 0 12px;
-  padding: 9px 11px;
-  border-radius: 9px;
-  font-size: 12.5px;
-  font-weight: 600;
-  line-height: 1.35;
-  color: #f0a868;
-  background: rgba(240, 136, 62, 0.12);
-  border: 1px solid rgba(240, 136, 62, 0.34);
-}
-
-.report-surge__icon {
-  flex: 0 0 auto;
-  font-size: 15px;
-}
-
-.report-surge__text {
-  min-width: 0;
-}
-
 .report-donut {
   display: flex;
   align-items: center;

--- a/public/report.css
+++ b/public/report.css
@@ -203,6 +203,7 @@
 
 /* Faster pulse when something is wrong. */
 .sp-beat--down .sp-beat-dot::after,
+.sp-beat--reported .sp-beat-dot::after,
 .sp-beat--degraded .sp-beat-dot::after { animation-duration: 1.1s; }
 /* No live pulse for an unknown status. */
 .sp-beat--unknown .sp-beat-dot { opacity: .5; }
@@ -415,6 +416,35 @@
 }
 
 /* Donut + legend */
+/* Surge banner: community reports spiking above normal. Warm amber (off the
+   green/amber/red status palette and not the old violet). Rendered inside the
+   report widget so the detail dialog and /status page share one design. */
+.report-surge {
+  box-sizing: border-box;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 12px;
+  padding: 9px 11px;
+  border-radius: 9px;
+  font-size: 12.5px;
+  font-weight: 600;
+  line-height: 1.35;
+  color: #f0a868;
+  background: rgba(240, 136, 62, 0.12);
+  border: 1px solid rgba(240, 136, 62, 0.34);
+}
+
+.report-surge__icon {
+  flex: 0 0 auto;
+  font-size: 15px;
+}
+
+.report-surge__text {
+  min-width: 0;
+}
+
 .report-donut {
   display: flex;
   align-items: center;
@@ -533,15 +563,45 @@
 }
 
 /* 7d report-volume sparkline (bars) */
-.report-spark {
-  display: flex;
-  align-items: stretch;
-  gap: 3px;
-  height: 44px;
-  padding: 0;
+/* 24h report-volume line chart (Downdetector-style): a line + faint area over a
+   shaded "typical range" band. A row of invisible columns (.report-spark__col)
+   overlays it for per-hour hover tooltips. */
+.report-chart {
+  position: relative;
+  height: 58px;
 }
 
-/* Full-height hover/focus target per day bucket */
+.report-chart__svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.report-chart__band {
+  fill: rgba(255, 255, 255, 0.07);
+}
+
+.report-chart__area {
+  fill: #22d3ee;
+  opacity: 0.14;
+}
+
+.report-chart__line {
+  fill: none;
+  stroke: #22d3ee;
+  stroke-width: 1.75;
+  stroke-linejoin: round;
+  stroke-linecap: round;
+  vector-effect: non-scaling-stroke;
+}
+
+.report-chart__cols {
+  position: absolute;
+  inset: 0;
+  display: flex;
+}
+
+/* Full-height hover/focus target per hour bucket */
 .report-spark__col {
   position: relative;
   flex: 1;

--- a/public/report.js
+++ b/public/report.js
@@ -440,22 +440,12 @@ function renderBreakdown(container, report) {
     return;
   }
 
-  const { total = 0, reasons = [], recent = [], hourly = [], countries = [], surge = false } = report;
+  const { total = 0, reasons = [], recent = [], hourly = [], countries = [] } = report;
 
   if (total === 0) {
     container.innerHTML = `<p class="report-widget__empty">No reports in the last 7 days.</p>`;
     return;
   }
-
-  // Surge banner: shown when community reports are spiking above this service's
-  // normal volume. Rendered inside the shared widget so the dialog and the
-  // /status page match. A user-perceived signal, distinct from official status.
-  const surgeHtml = surge
-    ? `<div class="report-surge" role="status">
-        <span class="report-surge__icon" aria-hidden="true">📈</span>
-        <span class="report-surge__text">Users are reporting problems — volume is spiking above normal.</span>
-      </div>`
-    : "";
 
   // Donut + legend, ordered by count desc.
   const ordered = [...reasons].filter((r) => r.count > 0).sort((a, b) => b.count - a.count);
@@ -484,7 +474,6 @@ function renderBreakdown(container, report) {
   }).join("");
 
   container.innerHTML = `
-    ${surgeHtml}
     <div class="report-donut">
       ${donutSvg(reasons, total)}
       <ul class="report-legend">${legendHtml}</ul>

--- a/public/report.js
+++ b/public/report.js
@@ -363,27 +363,54 @@ function getVotedReason(serviceId) {
 }
 
 /** Short date label for a day-bucket timestamp, e.g. "Jun 7". */
-function dayLabel(ts) {
-  return new Date(ts).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+function hourLabel(ts) {
+  return new Date(ts).toLocaleTimeString(undefined, { hour: "numeric" });
 }
 
-/** 7-day report-volume bar chart from the daily timeline. */
-function volumeChart(timeline) {
-  const total7 = timeline.reduce((s, p) => s + p.count, 0);
-  if (total7 === 0) {
-    return `<p class="report-section__empty">No reports in the last 7 days.</p>`;
+/**
+ * 24h report-volume chart from the hourly series: a Downdetector-style line +
+ * faint area, over a shaded "typical range" band (the 25th–75th percentile of
+ * the hour counts) so spikes above normal stand out. A row of invisible columns
+ * overlays the line to provide per-hour hover/focus tooltips.
+ */
+function volumeChart(hourly) {
+  const total = hourly.reduce((s, p) => s + p.count, 0);
+  if (total === 0) {
+    return `<p class="report-section__empty">No reports in the last 24 hours.</p>`;
   }
-  const max = Math.max(...timeline.map((p) => p.count), 1);
-  const bars = timeline.map((p) => {
-    const h = p.count === 0 ? 0 : Math.max(8, Math.round((p.count / max) * 100));
-    const tip = `${p.count} report${p.count === 1 ? "" : "s"} · ${dayLabel(p.t)}`;
-    // Full-height column is the hover/focus target so the whole bar slot is reachable.
-    return `<span class="report-spark__col" data-tip="${esc(tip)}" tabindex="0" role="img" aria-label="${esc(tip)}">
-      <span class="report-spark__bar${p.count ? "" : " is-empty"}" style="height:${h}%"></span>
-    </span>`;
-  }).join("");
-  return `<div class="report-spark" role="group" aria-label="Report volume over the last 7 days">${bars}</div>
-    <div class="report-spark__axis"><span>7d ago</span><span>today</span></div>`;
+  const values = hourly.map((p) => p.count);
+  const n = values.length;
+  const max = Math.max(...values, 1);
+  const PAD = 8; // top padding (viewBox units) so peaks aren't clipped
+  const y = (v) => 100 - PAD - (v / max) * (100 - PAD);
+  const line = values
+    .map((v, i) => `${(n <= 1 ? 0 : (i / (n - 1)) * 100).toFixed(1)},${y(v).toFixed(1)}`)
+    .join(" ");
+
+  // Typical-range band: 25th–75th percentile of the hourly counts.
+  const sorted = [...values].sort((a, b) => a - b);
+  const pct = (p) => sorted[Math.min(sorted.length - 1, Math.floor(p * (sorted.length - 1)))];
+  const q1 = pct(0.25);
+  const q3 = Math.max(pct(0.75), q1 + 0.5); // keep the band visible even when flat
+  const bandTop = y(q3);
+  const bandH = Math.max(0, y(q1) - bandTop);
+
+  const cols = hourly
+    .map((p) => {
+      const tip = `${p.count} report${p.count === 1 ? "" : "s"} · ${hourLabel(p.t)}`;
+      return `<span class="report-spark__col" data-tip="${esc(tip)}" tabindex="0" role="img" aria-label="${esc(tip)}"></span>`;
+    })
+    .join("");
+
+  return `<div class="report-chart" role="group" aria-label="Report volume over the last 24 hours">
+      <svg class="report-chart__svg" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
+        <rect class="report-chart__band" x="0" width="100" y="${bandTop.toFixed(1)}" height="${bandH.toFixed(1)}" />
+        <polygon class="report-chart__area" points="0,100 ${line} 100,100" />
+        <polyline class="report-chart__line" points="${line}" />
+      </svg>
+      <div class="report-chart__cols">${cols}</div>
+    </div>
+    <div class="report-spark__axis"><span>24h ago</span><span>now</span></div>`;
 }
 
 /** Top-5 countries by total reports, as labelled proportional bars. */
@@ -413,12 +440,22 @@ function renderBreakdown(container, report) {
     return;
   }
 
-  const { total = 0, reasons = [], recent = [], timeline = [], countries = [] } = report;
+  const { total = 0, reasons = [], recent = [], hourly = [], countries = [], surge = false } = report;
 
   if (total === 0) {
     container.innerHTML = `<p class="report-widget__empty">No reports in the last 7 days.</p>`;
     return;
   }
+
+  // Surge banner: shown when community reports are spiking above this service's
+  // normal volume. Rendered inside the shared widget so the dialog and the
+  // /status page match. A user-perceived signal, distinct from official status.
+  const surgeHtml = surge
+    ? `<div class="report-surge" role="status">
+        <span class="report-surge__icon" aria-hidden="true">📈</span>
+        <span class="report-surge__text">Users are reporting problems — volume is spiking above normal.</span>
+      </div>`
+    : "";
 
   // Donut + legend, ordered by count desc.
   const ordered = [...reasons].filter((r) => r.count > 0).sort((a, b) => b.count - a.count);
@@ -447,6 +484,7 @@ function renderBreakdown(container, report) {
   }).join("");
 
   container.innerHTML = `
+    ${surgeHtml}
     <div class="report-donut">
       ${donutSvg(reasons, total)}
       <ul class="report-legend">${legendHtml}</ul>
@@ -454,8 +492,8 @@ function renderBreakdown(container, report) {
     <p class="report-widget__total"><strong>${total}</strong> report${total === 1 ? "" : "s"} in the last 7 days</p>
 
     <hr class="report-rule" />
-    <p class="report-section__head">Report volume <span class="report-section__sub">7d</span></p>
-    ${volumeChart(timeline)}
+    <p class="report-section__head">Report volume <span class="report-section__sub">24h</span></p>
+    ${volumeChart(hourly)}
 
     <hr class="report-rule" />
     <p class="report-section__head">Top countries <span class="report-section__sub">7d</span></p>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1245,6 +1245,18 @@ body {
 	opacity: 0.16;
 }
 
+/* Solo view (a single service fills the grid): scale the sparkline up so it
+   reads as a proper chart instead of a thin capped strip at the bottom. */
+.grid--solo .tile__spark {
+	height: 30%;
+	max-height: 200px;
+	opacity: 1;
+}
+
+.grid--solo .tile__spark-line {
+	stroke-width: 2.2;
+}
+
 /* On a surging tile the fill is already the "reported" orange, so draw the line
    in a high-contrast white rather than a clashing accent. */
 .tile__spark-svg.is-surging .tile__spark-line {

--- a/public/styles.css
+++ b/public/styles.css
@@ -14,6 +14,11 @@
 	--down-hi: #fa5252;
 	--unknown: #495057;
 
+	/* Community-report surge overlay: deliberately off the status palette
+	   (violet) so it reads as an extra signal, not an outage color. */
+	--surge: #a855f7;
+	--surge-hi: #c084fc;
+
 	--grid-bg: #05070b;
 }
 
@@ -1183,6 +1188,59 @@ body {
 	opacity: 0.9;
 	text-transform: uppercase;
 	letter-spacing: 0.04em;
+}
+
+/* Surge badge: a pulsing dot in the tile corner when an anomalous number of
+   users are reporting problems. Supplementary to the tile's status color. */
+.tile__surge {
+	position: absolute;
+	top: 3px;
+	right: 3px;
+	width: 9px;
+	height: 9px;
+	border-radius: 50%;
+	background: var(--surge-hi);
+	box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.3), 0 0 7px var(--surge-hi);
+	animation: surge-pulse 1.8s ease-in-out infinite;
+}
+
+@keyframes surge-pulse {
+	0%,
+	100% {
+		transform: scale(1);
+		opacity: 0.95;
+	}
+	50% {
+		transform: scale(1.35);
+		opacity: 0.6;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.tile__surge {
+		animation: none;
+	}
+}
+
+/* Surge banner inside the service detail modal. */
+.detail__surge {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	margin: 0.7rem 0 0;
+	padding: 0.5rem 0.7rem;
+	border-radius: 8px;
+	font-size: 0.82rem;
+	font-weight: 600;
+	line-height: 1.3;
+	color: var(--surge-hi);
+	background: color-mix(in srgb, var(--surge) 14%, var(--panel));
+	border: 1px solid color-mix(in srgb, var(--surge) 40%, transparent);
+}
+
+.detail__surge-icon {
+	flex: 0 0 auto;
+	font-size: 1rem;
 }
 
 /* --- Toasts --- */

--- a/public/styles.css
+++ b/public/styles.css
@@ -14,10 +14,17 @@
 	--down-hi: #fa5252;
 	--unknown: #495057;
 
+	/* "Reported": probe is up/unknown but community reports are surging. A
+	   display-only status color (orange) — never persisted to incidents/uptime. */
+	--reported: #d9772e;
+	--reported-hi: #f0883e;
+
 	/* Community-report surge overlay: deliberately off the status palette
 	   (violet) so it reads as an extra signal, not an outage color. */
 	--surge: #a855f7;
 	--surge-hi: #c084fc;
+	/* Calm report-volume sparkline (cyan) — recolors to --surge-hi when surging. */
+	--spark: #22d3ee;
 
 	--grid-bg: #05070b;
 }
@@ -289,9 +296,10 @@ body {
 	flex: 0 0 auto;
 }
 
-/* Pulse the dot while anything is down/degraded to draw the eye. */
+/* Pulse the dot while anything is down/degraded/reported to draw the eye. */
 .statusbar__dot.is-down,
-.statusbar__dot.is-degraded {
+.statusbar__dot.is-degraded,
+.statusbar__dot.is-reported {
 	animation: status-pulse 1.8s ease-in-out infinite;
 }
 
@@ -301,6 +309,7 @@ body {
 }
 
 .statusbar__dot.is-up { background: var(--up-hi); color: var(--up-hi); }
+.statusbar__dot.is-reported { background: var(--reported-hi); color: var(--reported-hi); }
 .statusbar__dot.is-degraded { background: var(--degraded-hi); color: var(--degraded-hi); }
 .statusbar__dot.is-down { background: var(--down-hi); color: var(--down-hi); }
 .statusbar__dot.is-unknown { background: var(--unknown); color: var(--unknown); }
@@ -361,6 +370,7 @@ body {
 }
 
 /* Highlight the count chips that represent problems. */
+.legend__item[data-status="reported"],
 .legend__item[data-status="degraded"],
 .legend__item[data-status="down"] {
 	border-color: var(--border);
@@ -379,6 +389,7 @@ body {
 .legend__item.is-empty {
 	opacity: 0.45;
 }
+.legend__item.is-empty[data-status="reported"],
 .legend__item.is-empty[data-status="degraded"],
 .legend__item.is-empty[data-status="down"] {
 	border-color: transparent;
@@ -394,6 +405,9 @@ body {
 
 .swatch.is-up {
 	background: var(--up-hi);
+}
+.swatch.is-reported {
+	background: var(--reported-hi);
 }
 .swatch.is-degraded {
 	background: var(--degraded-hi);
@@ -740,6 +754,9 @@ body {
 }
 .cz-row .dot.is-up {
 	background: var(--up-hi);
+}
+.cz-row .dot.is-reported {
+	background: var(--reported-hi);
 }
 .cz-row .dot.is-degraded {
 	background: var(--degraded-hi);
@@ -1108,6 +1125,9 @@ body {
 .tile.is-up {
 	background: var(--up);
 }
+.tile.is-reported {
+	background: var(--reported);
+}
 .tile.is-degraded {
 	background: var(--degraded);
 }
@@ -1190,57 +1210,50 @@ body {
 	letter-spacing: 0.04em;
 }
 
-/* Surge badge: a pulsing dot in the tile corner when an anomalous number of
-   users are reporting problems. Supplementary to the tile's status color. */
-.tile__surge {
+/* Report-volume sparkline along the bottom of big tiles (Downdetector-style).
+   Supplementary overlay — does not affect the tile's status color. Recolors to
+   the surge hue when an anomalous number of users are reporting problems. */
+.tile__spark {
 	position: absolute;
-	top: 3px;
-	right: 3px;
-	width: 9px;
-	height: 9px;
-	border-radius: 50%;
-	background: var(--surge-hi);
-	box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.3), 0 0 7px var(--surge-hi);
-	animation: surge-pulse 1.8s ease-in-out infinite;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	height: 34%;
+	max-height: 38px;
+	pointer-events: none;
+	opacity: 0.92;
 }
 
-@keyframes surge-pulse {
-	0%,
-	100% {
-		transform: scale(1);
-		opacity: 0.95;
-	}
-	50% {
-		transform: scale(1.35);
-		opacity: 0.6;
-	}
+.tile__spark-svg {
+	display: block;
+	width: 100%;
+	height: 100%;
 }
 
-@media (prefers-reduced-motion: reduce) {
-	.tile__surge {
-		animation: none;
-	}
+.tile__spark-line {
+	fill: none;
+	stroke: var(--spark);
+	stroke-width: 1.6;
+	stroke-linejoin: round;
+	stroke-linecap: round;
+	/* Keep the line crisp despite the non-uniform preserveAspectRatio scaling. */
+	vector-effect: non-scaling-stroke;
 }
 
-/* Surge banner inside the service detail modal. */
-.detail__surge {
-	display: flex;
-	align-items: center;
-	gap: 0.5rem;
-	margin: 0.7rem 0 0;
-	padding: 0.5rem 0.7rem;
-	border-radius: 8px;
-	font-size: 0.82rem;
-	font-weight: 600;
-	line-height: 1.3;
-	color: var(--surge-hi);
-	background: color-mix(in srgb, var(--surge) 14%, var(--panel));
-	border: 1px solid color-mix(in srgb, var(--surge) 40%, transparent);
+.tile__spark-area {
+	fill: var(--spark);
+	opacity: 0.16;
 }
 
-.detail__surge-icon {
-	flex: 0 0 auto;
-	font-size: 1rem;
+/* On a surging tile the fill is already the "reported" orange, so draw the line
+   in a high-contrast white rather than a clashing accent. */
+.tile__spark-svg.is-surging .tile__spark-line {
+	stroke: rgba(255, 255, 255, 0.92);
+}
+
+.tile__spark-svg.is-surging .tile__spark-area {
+	fill: #ffffff;
+	opacity: 0.16;
 }
 
 /* --- Toasts --- */
@@ -1544,6 +1557,7 @@ body {
 }
 
 .modal__box.is-up      { border-top-color: var(--up-hi); }
+.modal__box.is-reported { border-top-color: var(--reported-hi); }
 .modal__box.is-degraded { border-top-color: var(--degraded-hi); }
 .modal__box.is-down    { border-top-color: var(--down-hi); }
 .modal__box.is-unknown { border-top-color: var(--unknown); }

--- a/schema-reports.sql
+++ b/schema-reports.sql
@@ -14,3 +14,19 @@ CREATE TABLE IF NOT EXISTS reports (
 );
 
 CREATE INDEX IF NOT EXISTS idx_reports_service_ts ON reports(service_id, ts);
+
+-- Per-service report-volume baseline for anomaly ("surge") detection. The cron
+-- counts reports in the trailing window each run and compares to this rolling
+-- baseline (EWMA mean plus variance). A sustained, statistically high count
+-- raises the surge flag. This is a supplementary signal only — it never alters
+-- the authoritative status pipeline (confirmStatus, incidents, snapshot color).
+-- See detectSurges() in src/reports.ts.
+CREATE TABLE IF NOT EXISTS report_baseline (
+	service_id  TEXT PRIMARY KEY,
+	ewma_rate   REAL    NOT NULL,           -- expected reports per detection bucket
+	ewma_var    REAL    NOT NULL,           -- variance estimate (for the z-score)
+	surge       INTEGER NOT NULL DEFAULT 0, -- 1 while the confirmed surge is open
+	streak      INTEGER NOT NULL DEFAULT 0, -- consecutive anomalous buckets (flap-damp)
+	surge_since INTEGER,                    -- epoch ms the surge opened, NULL when clear
+	updated_at  INTEGER NOT NULL            -- epoch ms of the last detection pass
+);

--- a/src/db.ts
+++ b/src/db.ts
@@ -93,6 +93,12 @@ export interface ApiService {
 	uptime: { day: number; week: number };
 	/** Reason the service is disabled (unreliable source), if applicable. */
 	disabled?: string;
+	/**
+	 * Community-report surge overlay: true when an anomalous number of users are
+	 * reporting problems right now (see detectSurges in src/reports.ts). Purely
+	 * supplementary — it never drives `status`/color, only a UI hint.
+	 */
+	surge?: boolean;
 }
 
 /**

--- a/src/db.ts
+++ b/src/db.ts
@@ -99,6 +99,12 @@ export interface ApiService {
 	 * supplementary — it never drives `status`/color, only a UI hint.
 	 */
 	surge?: boolean;
+	/**
+	 * 24h hourly report-volume series (oldest first) for the per-tile sparkline.
+	 * Omitted when a service has no reports in the window. Supplementary overlay
+	 * only (see reportSparklines in src/reports.ts).
+	 */
+	spark?: number[];
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import {
 	normalizeReason,
 	pruneReports,
 	readCount,
+	reportSparklines,
 	writeCount,
 	type VoteMessage,
 } from "./reports";
@@ -174,24 +175,30 @@ async function refreshSnapshot(env: Env): Promise<number> {
 	await persistSnapshot(env.DB, statuses);
 	const snapshot = await readSnapshot(env.DB);
 	if (snapshot) {
-		await decorateSurges(env, snapshot.services);
+		await decorateReports(env, snapshot.services);
 		await env.SNAPSHOT_KV.put(SNAPSHOT_KEY, JSON.stringify(snapshot));
 	}
 	return statuses.length;
 }
 
 /**
- * Overlay the Community-Report surge flag onto the snapshot before it's published
- * to KV. This is a supplementary hint, not authoritative status — so a failure in
- * the (separate) reports DB must never block the status snapshot: on any error we
- * log and leave `surge` unset.
+ * Overlay the Community-Report signals (surge flag + 24h sparkline) onto the
+ * snapshot before it's published to KV. These are supplementary hints, not
+ * authoritative status — so a failure in the (separate) reports DB must never
+ * block the status snapshot: on any error we log and leave the fields unset.
  */
-async function decorateSurges(env: Env, services: ApiService[]): Promise<void> {
+async function decorateReports(env: Env, services: ApiService[]): Promise<void> {
 	try {
 		const surges = await detectSurges(env.REPORTS_DB);
-		for (const s of services) s.surge = surges.get(s.id)?.surging ?? false;
+		const sparks = await reportSparklines(env.REPORTS_DB);
+		for (const s of services) {
+			s.surge = surges.get(s.id)?.surging ?? false;
+			const spark = sparks.get(s.id);
+			// Only attach a series with real activity — a flat all-zero line is noise.
+			if (spark && spark.some((n) => n > 0)) s.spark = spark;
+		}
 	} catch (err) {
-		console.error("surge detection failed (non-fatal):", err);
+		console.error("report decoration failed (non-fatal):", err);
 	}
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import {
 	aggregateReports,
 	countryOf,
 	DEDUP_WINDOW_MS,
+	detectSurges,
 	hashIp,
 	insertReports,
 	normalizeReason,
@@ -172,8 +173,26 @@ async function refreshSnapshot(env: Env): Promise<number> {
 	const statuses = await resolveAll(env.FETCH_ANALYTICS);
 	await persistSnapshot(env.DB, statuses);
 	const snapshot = await readSnapshot(env.DB);
-	if (snapshot) await env.SNAPSHOT_KV.put(SNAPSHOT_KEY, JSON.stringify(snapshot));
+	if (snapshot) {
+		await decorateSurges(env, snapshot.services);
+		await env.SNAPSHOT_KV.put(SNAPSHOT_KEY, JSON.stringify(snapshot));
+	}
 	return statuses.length;
+}
+
+/**
+ * Overlay the Community-Report surge flag onto the snapshot before it's published
+ * to KV. This is a supplementary hint, not authoritative status — so a failure in
+ * the (separate) reports DB must never block the status snapshot: on any error we
+ * log and leave `surge` unset.
+ */
+async function decorateSurges(env: Env, services: ApiService[]): Promise<void> {
+	try {
+		const surges = await detectSurges(env.REPORTS_DB);
+		for (const s of services) s.surge = surges.get(s.id)?.surging ?? false;
+	} catch (err) {
+		console.error("surge detection failed (non-fatal):", err);
+	}
 }
 
 // Per-isolate guard: kick at most one cold-start populate at a time so a burst of

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -213,7 +213,11 @@ export function renderServicePage(service: Service, current: ApiService | null, 
 	// Animated ECG "heartbeat" indicator — stroke colour follows the live status,
 	// and the hover tooltip reveals when the probe last ran.
 	const checked = formatUpdated(updatedAt);
-	const heartbeat = `<span class="sp-beat sp-beat--${display}" title="Checked ${escapeHtml(checked)}" aria-label="${beatLabel} — checked ${escapeHtml(checked)}">
+	// When surging, the indicator's hover tooltip explains the "Reported" state.
+	const beatTip = surging
+		? "Users are reporting problems — volume is spiking above normal."
+		: `Checked ${escapeHtml(checked)}`;
+	const heartbeat = `<span class="sp-beat sp-beat--${display}" title="${beatTip}" aria-label="${beatLabel} — checked ${escapeHtml(checked)}">
         <span class="sp-beat-label">${beatLabel}</span>
         <span class="sp-beat-dot" aria-hidden="true"></span>
       </span>`;

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -52,8 +52,17 @@ const STATUS_COPY: Record<StatusLevel, StatusCopy> = {
 	unknown: { label: "Unknown", tone: "unknown", sentence: (n) => `${n}'s current status is unavailable.` },
 };
 
-const STATUS_COLOR: Record<StatusLevel, string> = {
+/**
+ * Display-only status: the authoritative {@link StatusLevel} plus a "reported"
+ * state used when the probe is up/unknown but community reports are surging.
+ * Mirrors `effectiveStatus()` on the frontend — it colors the page, never the
+ * SEO copy or any persisted record.
+ */
+type DisplayStatus = StatusLevel | "reported";
+
+const STATUS_COLOR: Record<DisplayStatus, string> = {
 	up: "#3fb950",
+	reported: "#f0883e",
 	degraded: "#d29922",
 	down: "#f85149",
 	unknown: "#8b949e",
@@ -183,7 +192,13 @@ ${opts.scripts ?? ""}
 export function renderServicePage(service: Service, current: ApiService | null, updatedAt: number | null, mapKey = "", showMap = true): string {
 	const status: StatusLevel = current?.status ?? "unknown";
 	const copy = STATUS_COPY[status];
-	const color = STATUS_COLOR[status];
+	// Display-only: a surging up/unknown service shows as "reported" (orange).
+	// SEO copy below stays on the authoritative `status` so meta never claims an
+	// unconfirmed, crowd-sourced problem.
+	const surging = !!current?.surge && (status === "up" || status === "unknown");
+	const display: DisplayStatus = surging ? "reported" : status;
+	const beatLabel = surging ? "Reported" : copy.label;
+	const color = STATUS_COLOR[display];
 	const name = service.name;
 
 	const title = `Is ${name} down? Live ${name} status — isUpMap`;
@@ -198,8 +213,8 @@ export function renderServicePage(service: Service, current: ApiService | null, 
 	// Animated ECG "heartbeat" indicator — stroke colour follows the live status,
 	// and the hover tooltip reveals when the probe last ran.
 	const checked = formatUpdated(updatedAt);
-	const heartbeat = `<span class="sp-beat sp-beat--${status}" title="Checked ${escapeHtml(checked)}" aria-label="${copy.label} — checked ${escapeHtml(checked)}">
-        <span class="sp-beat-label">${copy.label}</span>
+	const heartbeat = `<span class="sp-beat sp-beat--${display}" title="Checked ${escapeHtml(checked)}" aria-label="${beatLabel} — checked ${escapeHtml(checked)}">
+        <span class="sp-beat-label">${beatLabel}</span>
         <span class="sp-beat-dot" aria-hidden="true"></span>
       </span>`;
 

--- a/src/reports.ts
+++ b/src/reports.ts
@@ -200,6 +200,132 @@ export async function pruneReports(db: D1Database, now = Date.now()): Promise<nu
 	return res.meta.changes ?? 0;
 }
 
+// ---- Surge detection (Downdetector-style anomaly signal) --------------------
+
+/**
+ * Trailing window whose report count is scored against the baseline. Wider than
+ * the 5-minute cron interval so consecutive passes overlap and a brief lull
+ * mid-incident doesn't drop the count to zero.
+ */
+export const SURGE_BUCKET_MS = 30 * 60 * 1000;
+/** z-score at/above which the live count counts as a statistical outlier. */
+export const SURGE_Z = 3;
+/**
+ * Absolute floor: never raise a surge on fewer than this many reports in the
+ * window, however large the z-score. This is the deliberate blind spot for
+ * low-traffic services — a handful of reports against a ~0 baseline yields a
+ * huge z, but is far too thin to call. Better a miss than a false outage.
+ */
+export const SURGE_MIN = 5;
+/**
+ * Consecutive anomalous buckets required before the surge is shown. Mirrors the
+ * status pipeline's CONFIRM_THRESHOLD (src/db.ts) so one noisy bucket can't flip
+ * the badge.
+ */
+export const SURGE_CONFIRM = 2;
+/** EWMA adaptation speed for the baseline (mean + variance). */
+const SURGE_ALPHA = 0.1;
+
+/** Per-service surge state returned by {@link detectSurges}. */
+export interface Surge {
+	serviceId: string;
+	/** Reports observed in the trailing {@link SURGE_BUCKET_MS} window. */
+	observed: number;
+	/** Expected reports for this service/window (baseline mean before this pass). */
+	baseline: number;
+	/** How many standard deviations above baseline the observed count is. */
+	z: number;
+	/** True once an anomaly has held for {@link SURGE_CONFIRM} consecutive buckets. */
+	surging: boolean;
+	/** Epoch ms the (confirmed) surge opened, if currently surging. */
+	since?: number;
+}
+
+interface BaselineRow {
+	service_id: string;
+	ewma_rate: number;
+	ewma_var: number;
+	surge: number;
+	streak: number;
+	surge_since: number | null;
+	updated_at: number;
+}
+
+/**
+ * Score each service's recent Community-Report volume against its own rolling
+ * baseline and update that baseline — the anomaly half of a Downdetector-style
+ * signal. Reads only the `reports` rows already collected; raises a `surging`
+ * flag when the trailing-window count is both a statistical outlier (z ≥
+ * {@link SURGE_Z}) and clears the absolute {@link SURGE_MIN} floor, sustained
+ * for {@link SURGE_CONFIRM} passes.
+ *
+ * Stateful: maintains `report_baseline` (EWMA mean + variance) across calls.
+ * The baseline is **frozen** while a service is anomalous so an ongoing surge
+ * can't retrain the model to expect outages. First-seen services are seeded and
+ * never surge on their first pass. Returns one entry per service that already
+ * had a baseline (i.e. excludes just-seeded ones).
+ *
+ * Supplementary only: callers overlay the result; it never feeds confirmStatus.
+ */
+export async function detectSurges(db: D1Database, now = Date.now()): Promise<Map<string, Surge>> {
+	const since = now - SURGE_BUCKET_MS;
+	const [countsRes, baseRes] = await db.batch([
+		db.prepare("SELECT service_id, COUNT(*) AS count FROM reports WHERE ts > ? GROUP BY service_id").bind(since),
+		db.prepare("SELECT * FROM report_baseline"),
+	]);
+
+	const counts = new Map((countsRes.results as { service_id: string; count: number }[]).map((r) => [r.service_id, r.count]));
+	const base = new Map((baseRes.results as BaselineRow[]).map((r) => [r.service_id, r]));
+
+	const upsert = db.prepare(
+		`INSERT INTO report_baseline (service_id, ewma_rate, ewma_var, surge, streak, surge_since, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)
+		 ON CONFLICT(service_id) DO UPDATE SET
+		   ewma_rate = excluded.ewma_rate, ewma_var = excluded.ewma_var, surge = excluded.surge,
+		   streak = excluded.streak, surge_since = excluded.surge_since, updated_at = excluded.updated_at`,
+	);
+
+	const out = new Map<string, Surge>();
+	const writes: D1PreparedStatement[] = [];
+
+	// Union of services with a baseline and/or reports this window: a baselined
+	// service with zero reports still needs its baseline to decay toward zero.
+	for (const id of new Set([...base.keys(), ...counts.keys()])) {
+		const observed = counts.get(id) ?? 0;
+		const prev = base.get(id);
+
+		// Cold start: seed the baseline, never surge on first sight.
+		if (!prev) {
+			writes.push(upsert.bind(id, observed, Math.max(observed, 1), 0, 0, null, now));
+			continue;
+		}
+
+		// Variance is floored at 1 so a long-quiet baseline (var → 0) still needs a
+		// few absolute reports — not a single one — to read as an outlier.
+		const std = Math.sqrt(Math.max(prev.ewma_var, 1));
+		const z = (observed - prev.ewma_rate) / std;
+		const anomalous = observed >= SURGE_MIN && z >= SURGE_Z;
+		const streak = anomalous ? prev.streak + 1 : 0;
+		const surging = streak >= SURGE_CONFIRM;
+		const since = surging ? (prev.surge_since ?? now) : null;
+
+		// Freeze the baseline while anomalous so the spike can't inflate "normal".
+		let rate = prev.ewma_rate;
+		let varr = prev.ewma_var;
+		if (!anomalous) {
+			const diff = observed - rate;
+			rate = SURGE_ALPHA * observed + (1 - SURGE_ALPHA) * rate;
+			varr = (1 - SURGE_ALPHA) * (varr + SURGE_ALPHA * diff * diff);
+		}
+
+		writes.push(upsert.bind(id, rate, varr, surging ? 1 : 0, streak, since, now));
+		out.set(id, { serviceId: id, observed, baseline: prev.ewma_rate, z, surging, since: since ?? undefined });
+	}
+
+	await db.batch(writes);
+	return out;
+}
+
 // ---- Edge glue --------------------------------------------------------------
 
 /** Normalize the CF country code, bucketing absent/unknown/Tor to "Unknown". */

--- a/src/reports.ts
+++ b/src/reports.ts
@@ -19,8 +19,14 @@ export const REPORT_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 /** One day, in ms — the bucket size for the 7-day report-volume timeline. */
 const DAY_MS = 24 * 60 * 60 * 1000;
 
+/** One hour, in ms — the bucket size for the 24h report-volume sparkline. */
+const HOUR_MS = 60 * 60 * 1000;
+
 /** Number of daily buckets in the report-volume timeline. */
 const TIMELINE_DAYS = 7;
+
+/** Number of hourly buckets in the 24h report-volume sparkline (tiles + chart). */
+export const SPARK_HOURS = 24;
 
 /** Delete reports older than this during the daily retention sweep. */
 const RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
@@ -65,6 +71,10 @@ export interface Report {
 	recent: RecentReport[];
 	/** 7 daily buckets over the last 7 days, oldest first (report-volume chart). */
 	timeline: TimelinePoint[];
+	/** 24 hourly buckets over the last 24h, oldest first (Downdetector-style chart). */
+	hourly: TimelinePoint[];
+	/** Whether community reports are currently surging (anomaly confirmed). */
+	surge: boolean;
 }
 
 /** Internal queue message shape — not part of the public API. */
@@ -144,6 +154,11 @@ interface DayRow {
 	count: number;
 }
 
+interface HourRow {
+	hour: number;
+	count: number;
+}
+
 /**
  * Aggregate recent reports for a service over the trailing REPORT_WINDOW_MS.
  * Returns 7-day totals plus per-country and per-reason breakdowns, the 10 newest
@@ -155,8 +170,12 @@ export async function aggregateReports(db: D1Database, serviceId: string, now = 
 	const nowDay = Math.floor(now / DAY_MS);
 	const firstDay = nowDay - (TIMELINE_DAYS - 1);
 	const since7 = firstDay * DAY_MS;
+	// 24h sparkline aligned to hour boundaries.
+	const nowHour = Math.floor(now / HOUR_MS);
+	const firstHour = nowHour - (SPARK_HOURS - 1);
+	const since24 = firstHour * HOUR_MS;
 
-	const [byCountry, byReason, latest, byDay] = await db.batch([
+	const [byCountry, byReason, latest, byDay, byHour, baseline] = await db.batch([
 		db
 			.prepare(
 				"SELECT country AS label, COUNT(*) AS count FROM reports WHERE service_id = ? AND ts > ? GROUP BY country ORDER BY count DESC",
@@ -177,6 +196,12 @@ export async function aggregateReports(db: D1Database, serviceId: string, now = 
 				"SELECT ts / 86400000 AS day, COUNT(*) AS count FROM reports WHERE service_id = ? AND ts >= ? GROUP BY day",
 			)
 			.bind(serviceId, since7),
+		db
+			.prepare(
+				"SELECT ts / 3600000 AS hour, COUNT(*) AS count FROM reports WHERE service_id = ? AND ts >= ? GROUP BY hour",
+			)
+			.bind(serviceId, since24),
+		db.prepare("SELECT surge FROM report_baseline WHERE service_id = ?").bind(serviceId),
 	]);
 
 	const countries = (byCountry.results as CountRow[]).map((r) => ({ country: r.label, count: r.count }));
@@ -191,7 +216,48 @@ export async function aggregateReports(db: D1Database, serviceId: string, now = 
 		timeline.push({ t: d * DAY_MS, count: dayCounts.get(d) ?? 0 });
 	}
 
-	return { windowMs: REPORT_WINDOW_MS, total, countries, reasons, recent, timeline };
+	// Densify the sparse hour rows into a contiguous 24-bucket array (oldest first).
+	const hourCounts = new Map((byHour.results as HourRow[]).map((r) => [r.hour, r.count]));
+	const hourly: TimelinePoint[] = [];
+	for (let h = firstHour; h <= nowHour; h++) {
+		hourly.push({ t: h * HOUR_MS, count: hourCounts.get(h) ?? 0 });
+	}
+
+	const surge = ((baseline.results as { surge: number }[])[0]?.surge ?? 0) === 1;
+
+	return { windowMs: REPORT_WINDOW_MS, total, countries, reasons, recent, timeline, hourly, surge };
+}
+
+/**
+ * 24h hourly report-volume series for *every* service that has reports, in one
+ * query — the per-tile sparkline data folded into the snapshot by the cron.
+ * Returns a contiguous {@link SPARK_HOURS}-length array (oldest first) per
+ * service; services with no reports in the window are absent from the map.
+ */
+export async function reportSparklines(db: D1Database, now = Date.now()): Promise<Map<string, number[]>> {
+	const nowHour = Math.floor(now / HOUR_MS);
+	const firstHour = nowHour - (SPARK_HOURS - 1);
+	const since = firstHour * HOUR_MS;
+
+	const res = await db
+		.prepare("SELECT service_id, ts / 3600000 AS hour, COUNT(*) AS count FROM reports WHERE ts >= ? GROUP BY service_id, hour")
+		.bind(since)
+		.all<{ service_id: string; hour: number; count: number }>();
+
+	const byService = new Map<string, Map<number, number>>();
+	for (const r of res.results) {
+		const hours = byService.get(r.service_id) ?? new Map<number, number>();
+		hours.set(r.hour, r.count);
+		byService.set(r.service_id, hours);
+	}
+
+	const out = new Map<string, number[]>();
+	for (const [id, hours] of byService) {
+		const arr: number[] = [];
+		for (let h = firstHour; h <= nowHour; h++) arr.push(hours.get(h) ?? 0);
+		out.set(id, arr);
+	}
+	return out;
 }
 
 /** Delete reports older than the retention window. Returns the row count removed. */

--- a/test/reports.test.ts
+++ b/test/reports.test.ts
@@ -8,6 +8,8 @@ import {
 	normalizeReason,
 	pruneReports,
 	REPORT_WINDOW_MS,
+	reportSparklines,
+	SPARK_HOURS,
 	SURGE_BUCKET_MS,
 } from "../src/reports";
 import type { Surge, VoteMessage } from "../src/reports";
@@ -112,6 +114,34 @@ describe("insertReports / aggregateReports", () => {
 		expect(report.countries).toHaveLength(0);
 		expect(report.reasons).toHaveLength(0);
 		expect(report.recent).toHaveLength(0);
+	});
+
+	it("surfaces the surge flag from report_baseline", async () => {
+		const now = Date.now();
+		await insertReports(env.REPORTS_DB, [vote("svc-a", "h1", "US", "errors", now)]);
+		// No baseline row yet → not surging.
+		expect((await aggregateReports(env.REPORTS_DB, "svc-a", now)).surge).toBe(false);
+		// A confirmed surge in report_baseline → reflected in the report payload.
+		await env.REPORTS_DB.prepare(
+			"INSERT INTO report_baseline (service_id, ewma_rate, ewma_var, surge, streak, surge_since, updated_at) VALUES ('svc-a', 1, 1, 1, 2, ?, ?)",
+		).bind(now, now).run();
+		expect((await aggregateReports(env.REPORTS_DB, "svc-a", now)).surge).toBe(true);
+	});
+
+	it("returns a 24-bucket hourly volume series", async () => {
+		const now = Date.now();
+		const hour = 60 * 60 * 1000;
+		await insertReports(env.REPORTS_DB, [
+			vote("svc-a", "h1", "US", "errors", now),           // this hour
+			vote("svc-a", "h2", "GB", "slow", now),             // this hour
+			vote("svc-a", "h3", "US", "unreachable", now - hour), // last hour
+			vote("svc-a", "h4", "DE", "other", now - 50 * hour),  // outside 24h window
+		]);
+		const report = await aggregateReports(env.REPORTS_DB, "svc-a", now);
+
+		expect(report.hourly).toHaveLength(SPARK_HOURS);
+		expect(report.hourly.at(-1)?.count).toBe(2); // newest bucket: 2 this hour
+		expect(report.hourly.reduce((s, p) => s + p.count, 0)).toBe(3); // the 50h-old one is excluded
 	});
 
 	it("returns a 7-bucket daily volume timeline", async () => {
@@ -255,6 +285,39 @@ describe("detectSurges", () => {
 		}
 		expect(res.get("svc-a")?.surging).toBe(true);
 		expect(res.get("svc-b")?.surging).toBe(false);
+	});
+});
+
+describe("reportSparklines", () => {
+	const hour = 60 * 60 * 1000;
+
+	it("returns a 24-bucket series per service with reports, oldest first", async () => {
+		const now = Date.now();
+		await insertReports(env.REPORTS_DB, [
+			vote("svc-a", "a1", "US", "errors", now),
+			vote("svc-a", "a2", "GB", "slow", now),
+			vote("svc-a", "a3", "US", "errors", now - hour),
+			vote("svc-b", "b1", "DE", "errors", now),
+		]);
+		const sparks = await reportSparklines(env.REPORTS_DB, now);
+
+		const a = sparks.get("svc-a");
+		expect(a).toHaveLength(SPARK_HOURS);
+		expect(a?.at(-1)).toBe(2); // newest hour
+		expect(a?.at(-2)).toBe(1); // previous hour
+		expect(a?.reduce((s, n) => s + n, 0)).toBe(3);
+		expect(sparks.get("svc-b")?.at(-1)).toBe(1);
+	});
+
+	it("omits services with no reports in the 24h window", async () => {
+		const now = Date.now();
+		await insertReports(env.REPORTS_DB, [
+			vote("svc-a", "old", "US", "errors", now - 50 * hour), // outside window
+			vote("svc-b", "new", "US", "errors", now),
+		]);
+		const sparks = await reportSparklines(env.REPORTS_DB, now);
+		expect(sparks.has("svc-a")).toBe(false);
+		expect(sparks.has("svc-b")).toBe(true);
 	});
 });
 

--- a/test/reports.test.ts
+++ b/test/reports.test.ts
@@ -3,12 +3,14 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import worker from "../src/index";
 import {
 	aggregateReports,
+	detectSurges,
 	insertReports,
 	normalizeReason,
 	pruneReports,
 	REPORT_WINDOW_MS,
+	SURGE_BUCKET_MS,
 } from "../src/reports";
-import type { VoteMessage } from "../src/reports";
+import type { Surge, VoteMessage } from "../src/reports";
 import schemaReportsSql from "../schema-reports.sql?raw";
 
 async function applySchema(sql: string) {
@@ -33,6 +35,7 @@ beforeAll(() => applySchema(schemaReportsSql));
 
 beforeEach(async () => {
 	await env.REPORTS_DB.prepare("DELETE FROM reports").run();
+	await env.REPORTS_DB.prepare("DELETE FROM report_baseline").run();
 });
 
 describe("normalizeReason", () => {
@@ -154,6 +157,104 @@ describe("pruneReports", () => {
 		expect(removed).toBe(1);
 		const remaining = await env.REPORTS_DB.prepare("SELECT COUNT(*) AS n FROM reports").first<{ n: number }>();
 		expect(remaining?.n).toBe(1);
+	});
+});
+
+describe("detectSurges", () => {
+	// Passes are spaced just past the 30-min detection window so each pass only
+	// "sees" the reports inserted for it — letting us script a volume timeline.
+	const STEP = SURGE_BUCKET_MS + 60 * 1000;
+
+	/** Insert `n` reports for `serviceId` inside the window ending at `at`, with unique IP hashes. */
+	async function reportsAt(serviceId: string, n: number, at: number, tag: string): Promise<void> {
+		if (n === 0) return;
+		const rows = Array.from({ length: n }, (_, i) => vote(serviceId, `${tag}-${i}`, "US", "errors", at - 1000));
+		await insertReports(env.REPORTS_DB, rows);
+	}
+
+	it("seeds a baseline on first sight and never surges on the first pass", async () => {
+		const t = Date.now();
+		await reportsAt("svc-a", 20, t, "first");
+		const result = await detectSurges(env.REPORTS_DB, t);
+		// First-seen service is seeded, not scored — absent from the output.
+		expect(result.get("svc-a")).toBeUndefined();
+		const row = await env.REPORTS_DB.prepare("SELECT * FROM report_baseline WHERE service_id = ?").bind("svc-a").first();
+		expect(row).not.toBeNull();
+		expect(row?.surge).toBe(0);
+	});
+
+	it("raises a surge after a sustained spike above a quiet baseline", async () => {
+		let t = Date.now();
+		// Warm a low, stable baseline (~1 report/window).
+		for (let i = 0; i < 3; i++) {
+			await reportsAt("svc-a", 1, t, `warm${i}`);
+			await detectSurges(env.REPORTS_DB, t);
+			t += STEP;
+		}
+		// First spike: anomalous but unconfirmed (one bucket).
+		await reportsAt("svc-a", 12, t, "spike1");
+		expect((await detectSurges(env.REPORTS_DB, t)).get("svc-a")?.surging).toBe(false);
+		t += STEP;
+		// Second consecutive spike: confirmed surge.
+		await reportsAt("svc-a", 12, t, "spike2");
+		const r = (await detectSurges(env.REPORTS_DB, t)).get("svc-a");
+		expect(r?.surging).toBe(true);
+		expect(r?.observed).toBe(12);
+		expect(r?.since).toBeDefined();
+	});
+
+	it("does not surge below the absolute floor, however high the z-score", async () => {
+		let t = Date.now();
+		for (let i = 0; i < 3; i++) {
+			await reportsAt("svc-a", 1, t, `warm${i}`);
+			await detectSurges(env.REPORTS_DB, t);
+			t += STEP;
+		}
+		// 4 reports is a big jump over a ~1 baseline (z ≥ 3) but under SURGE_MIN (5).
+		for (let i = 0; i < 3; i++) {
+			await reportsAt("svc-a", 4, t, `low${i}`);
+			expect((await detectSurges(env.REPORTS_DB, t)).get("svc-a")?.surging).toBe(false);
+			t += STEP;
+		}
+	});
+
+	it("clears the surge once volume returns to normal", async () => {
+		let t = Date.now();
+		for (let i = 0; i < 3; i++) {
+			await reportsAt("svc-a", 1, t, `warm${i}`);
+			await detectSurges(env.REPORTS_DB, t);
+			t += STEP;
+		}
+		for (let i = 0; i < 2; i++) {
+			await reportsAt("svc-a", 12, t, `spike${i}`);
+			await detectSurges(env.REPORTS_DB, t);
+			t += STEP;
+		}
+		// Quiet pass (no new reports in window) → surge clears.
+		const r = (await detectSurges(env.REPORTS_DB, t)).get("svc-a");
+		expect(r?.observed).toBe(0);
+		expect(r?.surging).toBe(false);
+	});
+
+	it("scores services independently", async () => {
+		let t = Date.now();
+		// Warm low baselines for both.
+		for (let i = 0; i < 3; i++) {
+			await reportsAt("svc-a", 1, t, `wa${i}`);
+			await reportsAt("svc-b", 1, t, `wb${i}`);
+			await detectSurges(env.REPORTS_DB, t);
+			t += STEP;
+		}
+		// svc-a spikes for two consecutive buckets; svc-b stays calm.
+		let res = new Map<string, Surge>();
+		for (let i = 0; i < 2; i++) {
+			await reportsAt("svc-a", 12, t, `sp${i}`);
+			await reportsAt("svc-b", 1, t, `sb${i}`);
+			res = await detectSurges(env.REPORTS_DB, t);
+			t += STEP;
+		}
+		expect(res.get("svc-a")?.surging).toBe(true);
+		expect(res.get("svc-b")?.surging).toBe(false);
 	});
 });
 


### PR DESCRIPTION
## What

Adds a **Downdetector-style anomaly signal** on top of the existing Community Reports and surfaces it across the UI — without touching the authoritative probe pipeline.

### Backend
- **`detectSurges()`** ([src/reports.ts](src/reports.ts)): each cron run scores a service's recent report volume against its own rolling EWMA baseline (mean + variance) and raises a **surge** when the count is a statistical outlier (≥3σ), clears an absolute floor (≥5 reports), and holds for 2 consecutive passes. Baseline is frozen during a surge so it can't retrain "normal"; first-seen services are seeded without surging.
- New `report_baseline` table ([schema-reports.sql](schema-reports.sql)).
- **24h hourly series**: `hourly` added to `/api/report/:id`, and `reportSparklines()` (all services) folded into the snapshot as a per-service `spark` array. The cron's `decorateReports()` stamps both `surge` + `spark`, fully try/catch-guarded so a reports-DB failure can **never** break the status snapshot.

### Frontend
- **Charts**: replaced the 7-day report bar chart with a 24h line + faint area over a shaded "typical range" (IQR) band, in the shared report widget (dialog + `/status/:id`). Big tiles get a 24h report-volume line **sparkline** (scaled up in solo/single-service view); small tiles render nothing.
- **"Reported" status color**: a display-only fifth state (orange) shown when the probe is `up`/`unknown` but reports are surging. Derived at render time via `effectiveStatus()` / display status across tiles, legend, statusbar, command palette, detail dialog, and the `/status` beat. Never replaces `svc.status` — incidents, uptime, and SEO copy stay probe-driven.
- The surge explanation ("Users are reporting problems — volume is spiking above normal.") shows as the **hover tooltip on the "Reported" indicator** (no standalone banner).

## Supplementary-only guarantee
Surge never opens an incident, never counts as downtime, and never changes the real status — it only adds **color + a sparkline + a tooltip**. Hardened against gaming by report dedup (1/person/day), the ≥5 floor, and the 2-pass confirm.

## Tests
120 passing (added: hourly aggregate, `reportSparklines`, surge confirm/floor/clear/isolation, surge flag in payload). Typecheck clean.

## Deploy note
Run `npm run db:schema:reports:remote` after merge to add the `report_baseline` table to the production reports DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)