### PR TITLE
feat: Atom incident feeds and 90-day uptime history

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ and a mobile-friendly detail sheet.
   **"Visit status page"** link.
 - **Incident history** — server-recorded incidents (open/close/duration),
   persisted in D1 and shown in a side panel and per-service (last 2 shown).
+- **90-day uptime history** — Statuspage-style daily bars (colored by each day's
+  worst incident status, with per-day uptime tooltips) plus the window average,
+  derived from the incident log. Shown in the detail modal and on the SSR
+  `/status/<id>` pages.
 - **Community "report it's down"** — users can vote a service is down with a
   reason (`Can't connect`, `Errors`, `Can't log in`, `Slow`, `Other`). Votes are
   deduplicated per IP-hash per 24 h, buffered through a Cloudflare Queue, and
@@ -45,6 +49,10 @@ and a mobile-friendly detail sheet.
   "problems only" filter, persisted in `localStorage`.
 - **Notifications** — in-page toasts on status changes, plus optional opt-in
   **desktop notifications**.
+- **Atom incident feeds** — subscribe to outages in any feed reader (or an
+  RSS-to-alert tool): [`/feed.xml`](https://isupmap.com/feed.xml) covers every
+  service, `/status/<id>/feed.xml` covers one. Entries update in place when an
+  incident resolves ("Resolved: GitHub was down for 25m").
 - **Light / dark theme**, deep links (`?service=`, `?filter=problems`), and a
   favicon/title that reflect overall state.
 
@@ -96,6 +104,20 @@ GET /api/report/:id ─▶ KV hit (10-min TTL) → or D1 aggregate query → rep
   cron) that the UI uses for the **"Reported"** tile color and per-tile sparkline.
 - `GET /api/incidents` returns the recent incident log from D1 (Cache-API fronted). An
   optional `?service=<id>` filter scopes it to a single service.
+- `GET /api/uptime/:id` returns a **90-day daily uptime series** for one service
+  (`{ date, uptime, worst }` per UTC day, oldest first, plus a `uptime90` window
+  average), computed from incident intervals — `degraded` counts against uptime,
+  matching the 24h/7d numbers. Same Cache-API + rate-limit fronting as
+  `/api/incidents` (5-min TTL). Approximations: days before a service was added
+  read 100%, and an incident whose severity changed carries its final status for
+  the whole interval.
+- `GET /feed.xml` (and per-service `GET /status/<id>/feed.xml`) serves the same
+  incident log as an **Atom feed** for feed readers and RSS-to-alert tools. Entry
+  ids are permanent and `<updated>` moves on resolution, so readers show recovery
+  as an update to the same item rather than a duplicate. The dashboard and SSR
+  pages advertise the feeds via `<link rel="alternate">` autodiscovery. Cache-API
+  fronted with a 5-min edge TTL (the cron cadence), so aggressive polling never
+  reaches D1.
 - `POST /api/report/:id` accepts a community down-report (`{ reason }`) for a known service.
   The IP is hashed with `VOTE_SALT` (SHA-256; never stored raw), deduplicated per IP-hash per
   24 h, and enqueued to `VOTE_QUEUE` for async batch-insert into `REPORTS_DB`. Tighter rate
@@ -403,6 +425,8 @@ curl "http://localhost:8787/__scheduled"      # runs scheduled() once → persis
 curl -s http://localhost:8787/api/status | jq # served from KV, includes per-service uptime + stale flag
 curl -s http://localhost:8787/api/incidents | jq
 curl -s http://localhost:8787/api/summary | jq # overall status rollup + headline
+curl -s http://localhost:8787/api/uptime/github | jq # 90-day daily uptime series
+curl -s http://localhost:8787/feed.xml         # Atom feed of the incident log
 ```
 
 > **Local cron note:** under plain `wrangler dev`, the documented
@@ -463,7 +487,7 @@ public/            Static frontend (served directly by Cloudflare)
   images/            OG image + self-hosted service icons (logo/services/<id>.png)
   lib/               Vendored MapLibre GL and Protomaps basemap assets (world map rendering)
 src/
-  index.ts           Worker entry: scheduled() cron + rate-limited/cached /api/* + SSR /status pages & /sitemap.xml
+  index.ts           Worker entry: scheduled() cron + rate-limited/cached /api/* + SSR /status pages, /sitemap.xml & Atom /feed.xml
   services.ts        Curated service list + status data sources + shared types
   sources.ts         Per-source-type fetch + normalize (Statuspage/RSS/HTTP); logs each attempt to AE
   analytics.ts       logFetch() helper — writes per-attempt fetch events to the Analytics Engine dataset

--- a/public/app.js
+++ b/public/app.js
@@ -1209,6 +1209,19 @@ async function openDetail(svc) {
 	if (widgetEl && window.isupReport) {
 		window.isupReport.mount(widgetEl, svc.id, { status: svc.status });
 	}
+	// 90-day uptime history: kicked off alongside the incidents fetch below and
+	// rendered whenever it lands. Section stays hidden until data arrives (and on
+	// error) — same no-flash rule as incident history.
+	fetch(`/api/uptime/${encodeURIComponent(svc.id)}`, { headers: { accept: "application/json" } })
+		.then((res) => res.json())
+		.then((data) => {
+			// Guard against a slow response after the user reopened a different service.
+			if (detailId !== svc.id) return;
+			if (data && Array.isArray(data.days) && data.days.length) renderDetailUptime(data);
+		})
+		.catch(() => {
+			/* leave the section hidden on error — nothing to show */
+		});
 	// Incident history for this service: the 2 most recent, queried per-service.
 	// The whole section stays hidden unless there's at least one incident (no
 	// flash while loading, no empty-state filler).
@@ -1286,6 +1299,16 @@ function renderDetailHeader(svc) {
 		<div class="detail__report-card">
 			<div data-report-widget data-service-id="${escapeHtml(svc.id)}"></div>
 		</div>
+		<section class="detail__uptime" hidden>
+			<div class="detail__section-head">
+				<h3 class="detail__subhead">90-day uptime</h3>
+				<span class="detail__uptime-agg"></span>
+			</div>
+			<div class="detail__uptime-body">
+				<div class="detail__uptime-bars"></div>
+				<div class="detail__uptime-scale" aria-hidden="true"><span>90 days ago</span><span>Today</span></div>
+			</div>
+		</section>
 		<section class="detail__history" hidden>
 			<div class="detail__section-head">
 				<h3 class="detail__subhead">Incident history</h3>
@@ -1305,6 +1328,20 @@ function renderDetailHeader(svc) {
 	// Render Lucide icons injected by the template.
 	const newIcons = [...detailBody.querySelectorAll("i[data-lucide]")];
 	if (newIcons.length) lucide.createIcons({ nodes: newIcons });
+}
+
+// Fill the (hidden) uptime section with one class-colored bar per UTC day and
+// the window average, then reveal it. `data` is the /api/uptime/:id payload.
+function renderDetailUptime(data) {
+	const section = detailBody.querySelector(".detail__uptime");
+	if (!section) return;
+	const pct = (fraction) => `${Math.round(fraction * 10000) / 100}%`;
+	const day = (date) => new Date(`${date}T00:00:00Z`).toLocaleString("en-US", { timeZone: "UTC", month: "short", day: "numeric" });
+	section.querySelector(".detail__uptime-agg").textContent = pct(data.uptime90);
+	section.querySelector(".detail__uptime-bars").innerHTML = data.days
+		.map((d) => `<span class="detail__ubar is-${escapeHtml(String(d.worst))}" title="${day(String(d.date))} — ${pct(d.uptime)}"></span>`)
+		.join("");
+	section.hidden = false;
 }
 
 function renderDetailIncidents(incidents) {

--- a/public/index.html
+++ b/public/index.html
@@ -29,6 +29,9 @@
 		<meta name="twitter:image" content="https://isupmap.com/images/og-map.png" />
 		<meta name="twitter:image:alt" content="isUpMap live service status heatmap showing AWS, GitHub, OpenAI, Cloudflare and more" />
 
+		<!-- Atom feed of the incident log (feed readers / RSS-to-alert tools). -->
+		<link rel="alternate" type="application/atom+xml" title="isUpMap — service incidents" href="https://isupmap.com/feed.xml" />
+
 		<!-- Real icon by default; app.js swaps #favicon for a live status-color dot at runtime. -->
 		<link rel="icon" id="favicon" type="image/png" href="/images/logo/icon/favicon-32x32.png" />
 		<link rel="shortcut icon" href="/images/logo/icon/favicon.ico" />

--- a/public/report.css
+++ b/public/report.css
@@ -123,6 +123,54 @@
   border-color: color-mix(in srgb, var(--status) 24%, rgba(255, 255, 255, .08));
 }
 
+/* ---- 90-day uptime card: one bar per UTC day, colored by worst status ---- */
+
+.sp-uptime-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin: 0 0 10px;
+}
+
+.sp-uptime-title {
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+  color: #8b949e;
+  margin: 0;
+}
+
+.sp-uptime-agg {
+  font-size: 15px;
+  font-weight: 700;
+  color: #e6edf3;
+}
+
+.sp-uptime-bars {
+  display: flex;
+  gap: 2px;
+  height: 28px;
+}
+
+.sp-ubar {
+  flex: 1;
+  min-width: 0;
+  border-radius: 2px;
+  background: #3fb950;
+}
+
+.sp-ubar--degraded { background: #d29922; }
+.sp-ubar--down { background: #f85149; }
+
+.sp-uptime-scale {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 6px;
+  font-size: 11px;
+  color: #8b949e;
+}
+
 /* Service identity row: logo · name/category · heartbeat */
 .sp-svc {
   display: flex;

--- a/public/styles.css
+++ b/public/styles.css
@@ -1800,6 +1800,41 @@ body {
 	padding: 0.3rem 1rem 1.2rem;
 }
 
+/* --- Detail 90-day uptime strip --- */
+.detail__uptime-agg {
+	margin-left: auto;
+	font-size: 0.7rem;
+	font-weight: 700;
+	color: var(--text);
+}
+
+.detail__uptime-body {
+	padding: 0.3rem 1.3rem 1rem;
+}
+
+.detail__uptime-bars {
+	display: flex;
+	gap: 2px;
+	height: 24px;
+}
+
+.detail__ubar {
+	flex: 1;
+	min-width: 0;
+	border-radius: 2px;
+	background: var(--up-hi);
+}
+.detail__ubar.is-degraded { background: var(--degraded-hi); }
+.detail__ubar.is-down     { background: var(--down-hi); }
+
+.detail__uptime-scale {
+	display: flex;
+	justify-content: space-between;
+	margin-top: 0.3rem;
+	font-size: 0.6rem;
+	color: var(--muted);
+}
+
 /* --- Detail incident cards --- */
 .detail-inc {
 	padding: 0.55rem 0.7rem;

--- a/src/db.ts
+++ b/src/db.ts
@@ -247,6 +247,57 @@ export async function readSnapshot(db: D1Database, now = Date.now()): Promise<{ 
 	return { updatedAt: lastRun ? Number(lastRun.value) : null, services };
 }
 
+/** One day of the 90-day uptime history (see {@link dailyUptime}). */
+export interface DailyUptime {
+	/** UTC calendar day, e.g. "2026-07-04". */
+	date: string;
+	/** Operational fraction (0..1) for the day; today is measured over elapsed time only. */
+	uptime: number;
+	/** Worst incident status overlapping the day (`up` when incident-free). */
+	worst: "up" | "degraded" | "down";
+}
+
+/**
+ * Per-UTC-day uptime for one service over the trailing `days` window, derived
+ * from incident intervals like {@link uptimeFraction} (so `degraded` counts
+ * against uptime too). Oldest day first; the last entry is today, measured over
+ * the elapsed part of the day. Approximations: days before a service was added
+ * read 100% (there's no first-seen marker), and an incident whose severity
+ * changed carries its final status for the whole interval (the row is updated
+ * in place).
+ */
+export async function dailyUptime(db: D1Database, serviceId: string, days = 90, now = Date.now()): Promise<DailyUptime[]> {
+	// Epoch ms are UTC-midnight aligned, so flooring to DAY_MS yields UTC midnight.
+	const todayStart = Math.floor(now / DAY_MS) * DAY_MS;
+	const windowStart = todayStart - (days - 1) * DAY_MS;
+
+	const rows = await db
+		.prepare("SELECT status, started_at, ended_at FROM incidents WHERE service_id = ? AND (ended_at IS NULL OR ended_at >= ?)")
+		.bind(serviceId, windowStart)
+		.all<{ status: StatusLevel; started_at: number; ended_at: number | null }>();
+
+	const result: DailyUptime[] = [];
+	for (let i = 0; i < days; i++) {
+		const dayStart = windowStart + i * DAY_MS;
+		const dayEnd = Math.min(dayStart + DAY_MS, now);
+		const elapsed = dayEnd - dayStart;
+		let downtime = 0;
+		let worst: DailyUptime["worst"] = "up";
+		for (const iv of rows.results) {
+			const start = Math.max(iv.started_at, dayStart);
+			const end = Math.min(iv.ended_at ?? now, dayEnd);
+			if (end <= start) continue;
+			downtime += end - start;
+			if (iv.status === "down") worst = "down";
+			else if (worst === "up") worst = "degraded";
+		}
+		// `elapsed` is 0 only when `now` is exactly UTC midnight; an empty day is fully up.
+		const uptime = elapsed > 0 ? Math.min(1, Math.max(0, 1 - downtime / elapsed)) : 1;
+		result.push({ date: new Date(dayStart).toISOString().slice(0, 10), uptime, worst });
+	}
+	return result;
+}
+
 /**
  * Most recent incidents (newest first), joined with the service name.
  * Pass `serviceId` to restrict to a single service (used by the detail sheet).

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,8 +11,8 @@
  *   - `GET /api/incidents`: recent incident log.
  */
 
-import { persistSnapshot, pruneIncidents, readSnapshot, recentIncidents, type ApiService } from "./db";
-import { findService, renderNotFound, renderServicePage, renderSitemap, renderStatusIndex } from "./pages";
+import { dailyUptime, persistSnapshot, pruneIncidents, readSnapshot, recentIncidents, type ApiService } from "./db";
+import { findService, renderIncidentFeed, renderNotFound, renderServicePage, renderSitemap, renderStatusIndex } from "./pages";
 import {
 	aggregateReports,
 	countryOf,
@@ -387,6 +387,29 @@ export default {
 			return resp;
 		}
 
+		// 90-day daily uptime history for one service (the detail modal's bar strip).
+		// Same shape as /api/incidents: one indexed D1 query, per-colo cached. A 5-min
+		// TTL matches the cron cadence (only today's bar can move between runs).
+		const uptimeMatch = url.pathname.match(/^\/api\/uptime\/([a-z0-9-]+)\/?$/);
+		if (uptimeMatch) {
+			const service = findService(uptimeMatch[1]);
+			if (!service) return json({ error: "Not found" }, { status: 404 });
+
+			const cache = caches.default;
+			const cacheKey = new Request(new URL(`/api/uptime/${service.id}`, url.origin).toString(), { method: "GET" });
+			const hit = await cache.match(cacheKey);
+			if (hit) return hit;
+
+			const limited = await rateLimit(request, env);
+			if (limited) return limited;
+
+			const days = await dailyUptime(env.DB, service.id);
+			const uptime90 = days.reduce((sum, d) => sum + d.uptime, 0) / days.length;
+			const resp = json({ serviceId: service.id, days, uptime90 }, { headers: { "cache-control": "public, max-age=300" } });
+			ctx.waitUntil(cache.put(cacheKey, resp.clone()));
+			return resp;
+		}
+
 		// Community report routes (/api/report/:id).
 		const reportMatch = url.pathname.match(/^\/api\/report\/([a-z0-9-]+)\/?$/);
 		if (reportMatch) {
@@ -458,6 +481,31 @@ export default {
 			return resp;
 		}
 
+		// Atom incident feeds: /feed.xml (all services) and /status/<id>/feed.xml
+		// (one service). Same D1 read as /api/incidents, fronted by the per-colo
+		// cache + rate limit; a 5-min edge TTL matches the cron cadence, so feed
+		// readers polling aggressively never touch D1 more than once per cycle.
+		const feedMatch = url.pathname.match(/^\/(?:status\/([a-z0-9-]+)\/)?feed\.xml$/);
+		if (feedMatch) {
+			const service = feedMatch[1] ? findService(feedMatch[1]) : undefined;
+			if (feedMatch[1] && !service) return new Response("Not found", { status: 404 });
+
+			const cache = caches.default;
+			const cacheKey = new Request(new URL(url.pathname, url.origin).toString(), { method: "GET" });
+			const hit = await cache.match(cacheKey);
+			if (hit) return hit;
+
+			const limited = await rateLimit(request, env);
+			if (limited) return limited;
+
+			const incidents = await recentIncidents(env.DB, 50, service?.id);
+			const resp = markup(renderIncidentFeed(incidents, service), "application/atom+xml; charset=utf-8", {
+				headers: { "cache-control": "public, max-age=300" },
+			});
+			ctx.waitUntil(cache.put(cacheKey, resp.clone()));
+			return resp;
+		}
+
 		// Crawlable sitemap, generated from SERVICES so it never drifts.
 		if (url.pathname === "/sitemap.xml") {
 			return markup(renderSitemap(), "application/xml; charset=utf-8", { headers: { "cache-control": "public, max-age=3600" } });
@@ -507,8 +555,14 @@ export default {
 				ctx.waitUntil(writeCount(env.SNAPSHOT_KV, service.id, reportSummary));
 			}
 			const showMap = reportSummary.total > 0 && Boolean(env.PROTOMAPS_KEY);
+			// 90-day uptime strip. One indexed D1 query behind the page's per-colo
+			// cache; a failure only drops the card, never the page.
+			const history = await dailyUptime(env.DB, service.id).catch((err) => {
+				console.error("uptime history failed (non-fatal):", err);
+				return undefined;
+			});
 			const resp = markup(
-				renderServicePage(service, current, snapshot.updatedAt, env.PROTOMAPS_KEY ?? "", showMap),
+				renderServicePage(service, current, snapshot.updatedAt, env.PROTOMAPS_KEY ?? "", showMap, history),
 				"text/html; charset=utf-8",
 				{},
 				{ allowSelfScripts: true, allowMap: showMap },

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -10,13 +10,16 @@
  *   - `/status`       — a directory of every tracked service, grouped by category.
  *   - `/sitemap.xml`  — the homepage plus every service page, generated from
  *                       {@link SERVICES} so it can never drift from the catalog.
+ *   - `/feed.xml` and `/status/<id>/feed.xml` — Atom feeds of the incident log,
+ *                       so any feed reader (or RSS-to-alert tool) can subscribe
+ *                       to outages without polling the JSON API.
  *
  * Pages are pure HTML with inline CSS and no scripts, so they render instantly
  * and need no client runtime. Status/uptime data is passed in by the caller
  * (read from D1), keeping this module free of bindings and easy to unit-test.
  */
 
-import type { ApiService } from "./db";
+import type { ApiService, DailyUptime, IncidentRecord } from "./db";
 import { SERVICES, type Service, type StatusLevel } from "./services";
 
 /** Canonical origin for <link rel=canonical>, OG tags, and the sitemap. */
@@ -144,6 +147,7 @@ isUpMap checks ${SERVICES.length}+ services every few minutes. Status reflects t
 <meta name="twitter:description" content="${escapeHtml(opts.description)}" />
 <meta name="twitter:image" content="${CANONICAL_ORIGIN}/images/og-map.png" />
 <link rel="icon" type="image/png" href="/images/logo/icon/favicon-32x32.png" />
+<link rel="alternate" type="application/atom+xml" title="isUpMap — service incidents" href="${CANONICAL_ORIGIN}/feed.xml" />
 <script type="application/ld+json">${JSON.stringify(opts.jsonLd)}</script>
 <style>
 :root { color-scheme: dark; }
@@ -179,6 +183,36 @@ ${opts.scripts ?? ""}
 </html>`;
 }
 
+/** "100%", "99.2%", "97.53%" — up to two decimals, trailing zeros dropped. */
+function formatPercent(fraction: number): string {
+	return `${Math.round(fraction * 10_000) / 100}%`;
+}
+
+/** Short UTC day label for bar tooltips, e.g. "Jul 3". */
+function formatDay(date: string): string {
+	return new Date(`${date}T00:00:00Z`).toLocaleString("en-US", { timeZone: "UTC", month: "short", day: "numeric" });
+}
+
+/**
+ * The 90-day uptime card: a strip of per-day bars (colored by the day's worst
+ * incident status, uptime in the hover tooltip) plus the window average.
+ */
+function renderUptimeCard(history: DailyUptime[]): string {
+	const avg = history.reduce((sum, d) => sum + d.uptime, 0) / history.length;
+	const bars = history
+		.map((d) => `<span class="sp-ubar sp-ubar--${d.worst}" title="${formatDay(d.date)} — ${formatPercent(d.uptime)}"></span>`)
+		.join("");
+	return `
+      <section class="sp-card sp-card--uptime">
+        <div class="sp-uptime-head">
+          <h2 class="sp-uptime-title">${history.length}-day uptime</h2>
+          <span class="sp-uptime-agg">${formatPercent(avg)}</span>
+        </div>
+        <div class="sp-uptime-bars" role="img" aria-label="Daily uptime over the last ${history.length} days: ${formatPercent(avg)} average">${bars}</div>
+        <div class="sp-uptime-scale" aria-hidden="true"><span>${history.length} days ago</span><span>Today</span></div>
+      </section>`;
+}
+
 /**
  * Full HTML for a single service's status page.
  *
@@ -188,8 +222,10 @@ ${opts.scripts ?? ""}
  * MapLibre/Protomaps assets it needs — are skipped entirely and the details
  * panel is centered, saving the heavy map download and tile requests.
  * `mapKey` is the Protomaps API key (empty string disables the GL map).
+ * `history` (per-UTC-day uptime, oldest first) renders the 90-day bar strip;
+ * omit it (or pass an empty array) to skip the card entirely.
  */
-export function renderServicePage(service: Service, current: ApiService | null, updatedAt: number | null, mapKey = "", showMap = true): string {
+export function renderServicePage(service: Service, current: ApiService | null, updatedAt: number | null, mapKey = "", showMap = true, history?: DailyUptime[]): string {
 	const status: StatusLevel = current?.status ?? "unknown";
 	const copy = STATUS_COPY[status];
 	// Display-only: a surging up/unknown service shows as "reported" (orange).
@@ -252,6 +288,10 @@ export function renderServicePage(service: Service, current: ApiService | null, 
 		],
 	};
 
+	// Statuspage-style 90-day uptime strip: one class-colored bar per UTC day
+	// (pure HTML/CSS — the page CSP allows no scripts beyond the report widget).
+	const uptimeCard = history?.length ? renderUptimeCard(history) : "";
+
 	// Scrollable info panel — shared by both the two-column (with map) and the
 	// centered solo (no map) layouts.
 	const panel = `
@@ -290,7 +330,7 @@ export function renderServicePage(service: Service, current: ApiService | null, 
           <span class="sp-ext-arrow" aria-hidden="true">↗</span>
         </a>
       </section>
-
+${uptimeCard}
       <section class="sp-card" data-report-widget data-service-id="${escapeHtml(service.id)}"></section>
 
       <footer>
@@ -323,7 +363,7 @@ export function renderServicePage(service: Service, current: ApiService | null, 
 		jsonLd,
 		body,
 		noWrap: true,
-		extraHead: `${mapCss}<link rel="stylesheet" href="/report.css" /><style>html,body{height:100%;overflow:hidden}</style>`,
+		extraHead: `${mapCss}<link rel="stylesheet" href="/report.css" /><link rel="alternate" type="application/atom+xml" title="${escapeHtml(name)} incidents — isUpMap" href="${canonical}/feed.xml" /><style>html,body{height:100%;overflow:hidden}</style>`,
 		scripts: `${mapJs}<script src="/report.js" type="module"></script>`,
 	});
 }
@@ -399,4 +439,70 @@ export function renderSitemap(): string {
 		.map((u) => `\t<url>\n\t\t<loc>${u.loc}</loc>\n\t\t<changefreq>${u.changefreq}</changefreq>\n\t\t<priority>${u.priority}</priority>\n\t</url>`)
 		.join("\n");
 	return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${body}\n</urlset>\n`;
+}
+
+/** Human-readable duration for feed copy, e.g. "45m", "3h 20m", "2d 5h". */
+function formatDuration(ms: number): string {
+	const minutes = Math.max(1, Math.round(ms / 60_000));
+	if (minutes < 60) return `${minutes}m`;
+	const hours = Math.floor(minutes / 60);
+	if (hours < 48) return `${hours}h${minutes % 60 ? ` ${minutes % 60}m` : ""}`;
+	const days = Math.floor(hours / 24);
+	return `${days}d${hours % 24 ? ` ${hours % 24}h` : ""}`;
+}
+
+/**
+ * Atom feed of the incident log — the whole map (`/feed.xml`) or a single
+ * service (`/status/<id>/feed.xml` when `service` is given). Atom over RSS 2.0
+ * because it has unambiguous timestamps and required entry ids.
+ *
+ * Entry ids are permanent (`/status/<sid>#incident-<row id>`), and `<updated>`
+ * moves when an incident resolves — so readers show recovery as an update to
+ * the same item rather than a duplicate. Incidents come from the caller (D1's
+ * {@link IncidentRecord}), keeping this module free of bindings.
+ */
+export function renderIncidentFeed(incidents: IncidentRecord[], service?: Service, now = Date.now()): string {
+	const feedUrl = service ? `${CANONICAL_ORIGIN}/status/${service.id}/feed.xml` : `${CANONICAL_ORIGIN}/feed.xml`;
+	const htmlUrl = service ? `${CANONICAL_ORIGIN}/status/${service.id}` : `${CANONICAL_ORIGIN}/`;
+	const title = service ? `${service.name} incidents — isUpMap` : "isUpMap — service incidents";
+	const subtitle = service
+		? `Outages and degraded-performance incidents for ${service.name}, detected by isUpMap's automated probes.`
+		: `Outages and degraded-performance incidents across the ${SERVICES.length}+ services isUpMap tracks.`;
+
+	// Feed-level <updated>: the newest activity in any entry (resolution counts), or `now` when empty.
+	const latest = incidents.reduce((max, i) => Math.max(max, i.endedAt ?? i.startedAt), 0);
+
+	const entries = incidents
+		.map((i) => {
+			const name = i.serviceName ?? i.serviceId;
+			const label = i.status === "down" ? "down" : "degraded";
+			const resolved = i.endedAt != null;
+			const entryTitle = resolved ? `Resolved: ${name} was ${label} for ${formatDuration(i.endedAt! - i.startedAt)}` : `${name} is ${label}`;
+			const when = resolved
+				? `Started ${formatUpdated(i.startedAt)}, resolved ${formatUpdated(i.endedAt!)}.`
+				: `Started ${formatUpdated(i.startedAt)}; ongoing as of the latest probe.`;
+			const summary = `${i.description ? `${i.description} — ` : ""}${when}`;
+			return `\t<entry>
+\t\t<title>${escapeHtml(entryTitle)}</title>
+\t\t<link href="${CANONICAL_ORIGIN}/status/${escapeHtml(i.serviceId)}"/>
+\t\t<id>${CANONICAL_ORIGIN}/status/${escapeHtml(i.serviceId)}#incident-${i.id}</id>
+\t\t<published>${new Date(i.startedAt).toISOString()}</published>
+\t\t<updated>${new Date(i.endedAt ?? i.startedAt).toISOString()}</updated>
+\t\t<summary>${escapeHtml(summary)}</summary>
+\t</entry>`;
+		})
+		.join("\n");
+
+	return `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+\t<title>${escapeHtml(title)}</title>
+\t<subtitle>${escapeHtml(subtitle)}</subtitle>
+\t<link href="${feedUrl}" rel="self" type="application/atom+xml"/>
+\t<link href="${htmlUrl}"/>
+\t<id>${feedUrl}</id>
+\t<updated>${new Date(latest || now).toISOString()}</updated>
+\t<author><name>isUpMap</name></author>
+${entries}
+</feed>
+`;
 }

--- a/test/feed.test.ts
+++ b/test/feed.test.ts
@@ -1,0 +1,134 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { IncidentRecord } from "../src/db";
+import { persistSnapshot } from "../src/db";
+import worker from "../src/index";
+import { renderIncidentFeed } from "../src/pages";
+import { SERVICES, type ServiceStatus, type StatusLevel } from "../src/services";
+import schemaSql from "../schema.sql?raw";
+
+function incident(over: Partial<IncidentRecord> = {}): IncidentRecord {
+	return {
+		id: 1,
+		serviceId: "github",
+		serviceName: "GitHub",
+		category: "Developer & Cloud",
+		status: "down",
+		description: "Major outage",
+		startedAt: 1_700_000_000_000,
+		endedAt: null,
+		...over,
+	};
+}
+
+describe("renderIncidentFeed", () => {
+	it("renders a valid Atom skeleton even with no incidents", () => {
+		const xml = renderIncidentFeed([], undefined, 1_700_000_000_000);
+		expect(xml).toContain(`<feed xmlns="http://www.w3.org/2005/Atom">`);
+		expect(xml).toContain("<id>https://isupmap.com/feed.xml</id>");
+		expect(xml).toContain(`<link href="https://isupmap.com/feed.xml" rel="self"`);
+		expect(xml).toContain(`<updated>${new Date(1_700_000_000_000).toISOString()}</updated>`);
+		expect(xml).not.toContain("<entry>");
+	});
+
+	it("renders an ongoing incident with a stable id and start time", () => {
+		const xml = renderIncidentFeed([incident({ id: 42 })]);
+		expect(xml).toContain("<title>GitHub is down</title>");
+		expect(xml).toContain("<id>https://isupmap.com/status/github#incident-42</id>");
+		expect(xml).toContain(`<published>${new Date(1_700_000_000_000).toISOString()}</published>`);
+		expect(xml).toContain("ongoing as of the latest probe");
+		expect(xml).toContain(`<link href="https://isupmap.com/status/github"/>`);
+	});
+
+	it("renders a resolved incident with duration, moving <updated> to the resolution", () => {
+		const endedAt = 1_700_000_000_000 + 25 * 60_000;
+		const xml = renderIncidentFeed([incident({ status: "degraded", endedAt })]);
+		expect(xml).toContain("<title>Resolved: GitHub was degraded for 25m</title>");
+		expect(xml).toContain(`<updated>${new Date(endedAt).toISOString()}</updated>`);
+	});
+
+	it("falls back to the service id when the name join is null", () => {
+		const xml = renderIncidentFeed([incident({ serviceName: null })]);
+		expect(xml).toContain("<title>github is down</title>");
+	});
+
+	it("escapes untrusted description text", () => {
+		const xml = renderIncidentFeed([incident({ description: `<script>alert("x")</script> & more` })]);
+		expect(xml).not.toContain("<script>");
+		expect(xml).toContain("&lt;script&gt;");
+		expect(xml).toContain("&amp; more");
+	});
+
+	it("scopes title, self link, and id to the service when one is given", () => {
+		const svc = SERVICES.find((s) => s.id === "github")!;
+		const xml = renderIncidentFeed([incident()], svc);
+		expect(xml).toContain("<title>GitHub incidents — isUpMap</title>");
+		expect(xml).toContain("<id>https://isupmap.com/status/github/feed.xml</id>");
+		expect(xml).toContain(`<link href="https://isupmap.com/status/github/feed.xml" rel="self"`);
+	});
+});
+
+describe("feed routes", () => {
+	async function applySchema(sql: string) {
+		const statements = sql
+			.split(";")
+			.map((chunk) =>
+				chunk
+					.split("\n")
+					.filter((line) => !line.trim().startsWith("--"))
+					.join("\n")
+					.trim(),
+			)
+			.filter((s) => s.length > 0);
+		for (const stmt of statements) await env.DB.prepare(stmt).run();
+	}
+
+	beforeAll(() => applySchema(schemaSql));
+
+	beforeEach(async () => {
+		await env.DB.batch([env.DB.prepare("DELETE FROM incidents"), env.DB.prepare("DELETE FROM current"), env.DB.prepare("DELETE FROM probe_state")]);
+	});
+
+	function status(id: string, level: StatusLevel, description = ""): ServiceStatus {
+		return { id, name: id.toUpperCase(), category: "Test", weight: 1, status: level, description };
+	}
+
+	/** Open a confirmed incident: a non-up status must hold CONFIRM_THRESHOLD (2) polls. */
+	async function openIncident(id: string, level: StatusLevel) {
+		await persistSnapshot(env.DB, [status(id, level)], 1_700_000_000_000);
+		await persistSnapshot(env.DB, [status(id, level, "It broke")], 1_700_000_300_000);
+	}
+
+	async function get(path: string): Promise<Response> {
+		const req = new Request(`http://localhost${path}`);
+		const ctx = createExecutionContext();
+		const res = await worker.fetch(req, env, ctx);
+		await waitOnExecutionContext(ctx);
+		return res;
+	}
+
+	it("serves the global Atom feed with open incidents", async () => {
+		await openIncident("github", "down");
+		const res = await get("/feed.xml");
+		expect(res.status).toBe(200);
+		expect(res.headers.get("content-type")).toContain("application/atom+xml");
+		const xml = await res.text();
+		expect(xml).toContain("GITHUB is down");
+		expect(xml).toContain("/status/github#incident-");
+	});
+
+	it("scopes /status/<id>/feed.xml to that service", async () => {
+		await openIncident("github", "down");
+		await openIncident("npm", "degraded");
+		const res = await get("/status/github/feed.xml");
+		expect(res.status).toBe(200);
+		const xml = await res.text();
+		expect(xml).toContain("GITHUB is down");
+		expect(xml).not.toContain("NPM");
+	});
+
+	it("404s a feed for an unknown service", async () => {
+		const res = await get("/status/definitely-not-a-service/feed.xml");
+		expect(res.status).toBe(404);
+	});
+});

--- a/test/pages.test.ts
+++ b/test/pages.test.ts
@@ -62,6 +62,23 @@ describe("renderServicePage", () => {
 		expect(html).not.toContain("<img src=x");
 		expect(html).toContain("&lt;img src=x");
 	});
+
+	it("renders the 90-day uptime strip only when history is provided", () => {
+		const history = [
+			{ date: "2026-07-02", uptime: 1, worst: "up" as const },
+			{ date: "2026-07-03", uptime: 0.958, worst: "down" as const },
+			{ date: "2026-07-04", uptime: 0.99, worst: "degraded" as const },
+		];
+		const html = renderServicePage(svc, apiService(svc.id, "up"), 1000, "", true, history);
+		expect(html).toContain("3-day uptime"); // heading reflects the window length
+		expect((html.match(/sp-ubar /g) ?? []).length).toBe(3); // one bar per day
+		expect(html).toContain("sp-ubar--down");
+		expect(html).toContain(`title="Jul 3 — 95.8%"`);
+		expect(html).toContain("98.27%"); // window average of the three days
+
+		const without = renderServicePage(svc, apiService(svc.id, "up"), 1000);
+		expect(without).not.toContain("sp-uptime-bars");
+	});
 });
 
 describe("findService", () => {

--- a/test/uptime.test.ts
+++ b/test/uptime.test.ts
@@ -1,0 +1,106 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { dailyUptime } from "../src/db";
+import worker from "../src/index";
+import schemaSql from "../schema.sql?raw";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+/** Fixed "now": 2026-07-04T12:00:00Z — a half-elapsed UTC day. */
+const NOW = Date.UTC(2026, 6, 4, 12);
+const TODAY_START = Date.UTC(2026, 6, 4);
+
+async function applySchema(sql: string) {
+	const statements = sql
+		.split(";")
+		.map((chunk) =>
+			chunk
+				.split("\n")
+				.filter((line) => !line.trim().startsWith("--"))
+				.join("\n")
+				.trim(),
+		)
+		.filter((s) => s.length > 0);
+	for (const stmt of statements) await env.DB.prepare(stmt).run();
+}
+
+beforeAll(() => applySchema(schemaSql));
+
+beforeEach(async () => {
+	await env.DB.batch([env.DB.prepare("DELETE FROM incidents"), env.DB.prepare("DELETE FROM current")]);
+});
+
+function insertIncident(serviceId: string, status: string, startedAt: number, endedAt: number | null) {
+	return env.DB.prepare("INSERT INTO incidents (service_id, status, description, started_at, ended_at) VALUES (?, ?, NULL, ?, ?)")
+		.bind(serviceId, status, startedAt, endedAt)
+		.run();
+}
+
+describe("dailyUptime", () => {
+	it("returns one fully-up entry per day when there are no incidents", async () => {
+		const days = await dailyUptime(env.DB, "github", 90, NOW);
+		expect(days).toHaveLength(90);
+		expect(days.every((d) => d.uptime === 1 && d.worst === "up")).toBe(true);
+		expect(days[89].date).toBe("2026-07-04"); // newest last
+		expect(days[0].date).toBe(new Date(TODAY_START - 89 * DAY_MS).toISOString().slice(0, 10));
+	});
+
+	it("splits an incident spanning a UTC midnight across both days", async () => {
+		// 23:00 July 3 → 01:00 July 4: one hour against each day.
+		await insertIncident("github", "down", TODAY_START - 60 * 60_000, TODAY_START + 60 * 60_000);
+		const days = await dailyUptime(env.DB, "github", 90, NOW);
+		const [yesterday, today] = days.slice(-2);
+		expect(yesterday.uptime).toBeCloseTo(1 - 1 / 24, 6);
+		expect(yesterday.worst).toBe("down");
+		// Today is measured over its elapsed 12 hours.
+		expect(today.uptime).toBeCloseTo(1 - 1 / 12, 6);
+		expect(today.worst).toBe("down");
+	});
+
+	it("clamps an open (unresolved) incident at now", async () => {
+		await insertIncident("github", "degraded", NOW - 2 * 60 * 60_000, null);
+		const days = await dailyUptime(env.DB, "github", 90, NOW);
+		const today = days[89];
+		expect(today.uptime).toBeCloseTo(1 - 2 / 12, 6);
+		expect(today.worst).toBe("degraded");
+	});
+
+	it("down beats degraded for a day's worst status", async () => {
+		await insertIncident("github", "degraded", NOW - 4 * 60 * 60_000, NOW - 3 * 60 * 60_000);
+		await insertIncident("github", "down", NOW - 2 * 60 * 60_000, NOW - 60 * 60_000);
+		const days = await dailyUptime(env.DB, "github", 90, NOW);
+		expect(days[89].worst).toBe("down");
+		expect(days[89].uptime).toBeCloseTo(1 - 2 / 12, 6);
+	});
+
+	it("ignores incidents fully outside the window and other services", async () => {
+		await insertIncident("github", "down", NOW - 100 * DAY_MS, NOW - 95 * DAY_MS);
+		await insertIncident("npm", "down", NOW - 60 * 60_000, null);
+		const days = await dailyUptime(env.DB, "github", 90, NOW);
+		expect(days.every((d) => d.uptime === 1 && d.worst === "up")).toBe(true);
+	});
+});
+
+describe("GET /api/uptime/:id", () => {
+	async function get(path: string): Promise<Response> {
+		const req = new Request(`http://localhost${path}`);
+		const ctx = createExecutionContext();
+		const res = await worker.fetch(req, env, ctx);
+		await waitOnExecutionContext(ctx);
+		return res;
+	}
+
+	it("serves 90 daily entries plus the window average for a known service", async () => {
+		const res = await get("/api/uptime/github");
+		expect(res.status).toBe(200);
+		expect(res.headers.get("content-type")).toContain("application/json");
+		const body = (await res.json()) as { serviceId: string; days: unknown[]; uptime90: number };
+		expect(body.serviceId).toBe("github");
+		expect(body.days).toHaveLength(90);
+		expect(body.uptime90).toBe(1); // empty incidents table → fully up
+	});
+
+	it("404s an unknown service id", async () => {
+		const res = await get("/api/uptime/definitely-not-a-service");
+		expect(res.status).toBe(404);
+	});
+});


### PR DESCRIPTION
## What does this PR do?

Adds two features built on the existing incident log — no new bindings, no schema changes:

**Atom incident feeds** — subscribe to outages in any feed reader or RSS-to-alert tool:
- `GET /feed.xml` (all services) and `GET /status/<id>/feed.xml` (one service), rendered by a binding-free `renderIncidentFeed()` in `src/pages.ts`.
- Entry ids are permanent (`/status/<id>#incident-<row id>`) and `<updated>` moves on resolution, so readers show recovery as an update to the same item ("Resolved: GitHub was down for 25m") rather than a duplicate.
- Advertised via `<link rel="alternate" type="application/atom+xml">` autodiscovery on the dashboard and all SSR pages.

**90-day uptime history** — Statuspage-style daily bars derived from incident intervals:
- `GET /api/uptime/:id` returns `{ date, uptime, worst }` per UTC day (oldest first) plus a `uptime90` window average. `degraded` counts against uptime, consistent with the existing 24h/7d numbers; today is measured over elapsed time; incidents pruned at 90 days align exactly with the window.
- Bar strip (colored by each day's worst status, per-day uptime tooltips, window average) on the SSR `/status/<id>` pages — pure HTML/CSS under the locked-down CSP — and in the dashboard detail modal, fetched in parallel with incident history.
- Documented approximations: days before a service was added read 100%; a severity-changed incident carries its final status for the whole interval.

Both read paths follow the `/api/incidents` pattern: per-colo Cache API + per-IP rate limit (5-min edge TTL, matching the cron cadence), never touching the KV hot path. On the SSR page a failed uptime read only drops the card, never the page.

## Type of change

- [ ] New service
- [ ] Bug fix
- [x] UI change
- [x] Other (please describe): new API endpoint + Atom feeds

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm test` passes (137 tests, 17 new across `test/feed.test.ts`, `test/uptime.test.ts`, and `test/pages.test.ts`)
- [ ] For a UI change, I've attached a screenshot
- [ ] For a new service, I've followed [CONTRIBUTING.md](../CONTRIBUTING.md) (source type + category + logo)
- [x] PR is focused (one service or one fix)

## Verification

Beyond the workerd integration tests (which drive the real worker with local D1), verified live with `wrangler dev --config wrangler.prod.jsonc`: the uptime API returns 90 correct days and 404s unknown ids; after inserting a 6-hour test outage into local D1, the SSR page rendered 90 bars with "Jul 3 — 75%" on the down day and a 99.72% average, and the 5-min edge cache behaved as designed.

## Related issues

—

🤖 Generated with [Claude Code](https://claude.com/claude-code)